### PR TITLE
Add multi-component example to show how state can be shared

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,5 @@ members = [
   "examples/store",
   "examples/functional",
   "examples/input",
+  "examples/multi_component",
 ]

--- a/examples/multi_component/Cargo.toml
+++ b/examples/multi_component/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "multi_component"
+version = "0.1.0"
+authors = ["William Brown <william@blackhats.net.au>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde = { version = "1.0.114", features = ["rc"] }
+yewdux = { path = "../../yewdux" }
+yew = { git = "https://github.com/yewstack/yew.git" }
+yewtil = {  git = "https://github.com/yewstack/yew.git" }
+yew-services = { git = "https://github.com/yewstack/yew.git" }

--- a/examples/multi_component/index.html
+++ b/examples/multi_component/index.html
@@ -1,0 +1,4 @@
+<html>
+  <head>
+  </head>
+</html>

--- a/examples/multi_component/src/main.rs
+++ b/examples/multi_component/src/main.rs
@@ -1,0 +1,115 @@
+use std::rc::Rc;
+
+use yew::prelude::*;
+use yewdux::prelude::*;
+use yew_services::ConsoleService;
+
+#[derive(Default, Clone)]
+struct State {
+    count: u32,
+}
+
+struct App {
+    /// Our local version of state.
+    state: Rc<State>,
+    dispatch: Dispatch<BasicStore<State>>,
+    link: ComponentLink<Self>,
+}
+
+enum Msg {
+    /// Message to receive new state.
+    State(Rc<State>),
+    Increment,
+}
+
+impl Component for App {
+    type Message = Msg;
+    type Properties = ();
+
+    fn create(_props: Self::Properties, link: ComponentLink<Self>) -> Self {
+        Self {
+            dispatch: Dispatch::bridge_state(link.callback(Msg::State)),
+            state: Default::default(),
+            link,
+        }
+    }
+
+    fn update(&mut self, msg: Self::Message) -> ShouldRender {
+        match msg {
+            Msg::State(state) => {
+                self.state = state;
+                true
+            }
+            Msg::Increment => {
+                self.dispatch.reduce(|s| {
+                    ConsoleService::log("count += 1");
+                    s.count += 1
+                });
+                true
+            }
+        }
+    }
+
+    fn change(&mut self, _props: Self::Properties) -> ShouldRender {
+        false
+    }
+
+    fn view(&self) -> Html {
+        // We use self.link.callback here because onclick = dispatch_withcallback appears
+        // to not be working at this time.
+        html! {
+            <>
+                <CountApp/>
+                <CountApp/>
+                <button onclick=self.link.callback(|_| Msg::Increment)>{"+1"}</button>
+            </>
+        }
+    }
+}
+
+struct CountApp {
+    state: Rc<State>,
+    _dispatch: Dispatch<BasicStore<State>>,
+}
+
+enum CountMsg {
+    /// Message to receive new state.
+    State(Rc<State>),
+}
+
+impl Component for CountApp {
+    type Message = CountMsg;
+    type Properties = ();
+
+    fn create(_props: Self::Properties, link: ComponentLink<Self>) -> Self {
+        Self {
+            _dispatch: Dispatch::bridge_state(link.callback(CountMsg::State)),
+            state: Default::default(),
+        }
+    }
+
+    fn update(&mut self, msg: Self::Message) -> ShouldRender {
+        match msg {
+            CountMsg::State(state) => {
+                self.state = state;
+                true
+            }
+        }
+    }
+
+    fn change(&mut self, _props: Self::Properties) -> ShouldRender {
+        false
+    }
+
+    fn view(&self) -> Html {
+        let count = self.state.count;
+        html! {
+            <h1>{ count }</h1>
+        }
+    }
+}
+
+
+pub fn main() {
+    yew::start_app::<App>();
+}


### PR DESCRIPTION
This adds a multi component example to demonstrate how state can be shared between components that may want to receive updates. I'm sure there could be better approaches and improvements to this, so I'd like to hear that feedback!

note: I wasn't able to use `let onclick = self.dispatch.reduce_callback(|s| s.count += 1);` because it wasn't work in latest chrome/edge, but it appears this also fails to trigger a callback right now in all examples of the project, so maybe there is currently a bug there? 