### PR TITLE
Align to latest yew and apply cargo-clippy

### DIFF
--- a/yewdux/src/component/wrapper.rs
+++ b/yewdux/src/component/wrapper.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 
 use yew::prelude::*;
 
-use crate::dispatch::{Dispatch, DispatchProps, WithDispatchProps};
+use crate::dispatch::{Dispatch, WithDispatchProps};
 use crate::store::Store;
 
 type PropStore<PROPS> = <PROPS as WithDispatchProps>::Store;
@@ -23,6 +23,8 @@ where
 /// Wraps any component with properties that implement
 /// [DispatchProps](crate::dispatch::DispatchPropsMut):
 /// ```
+/// # use yewdux::component::WithDispatch;
+/// # struct MyComponent;
 /// pub type App = WithDispatch<MyComponent>;
 /// ```
 pub struct WithDispatch<C>

--- a/yewdux/src/dispatch.rs
+++ b/yewdux/src/dispatch.rs
@@ -115,7 +115,6 @@ pub trait Dispatcher {
         Callback::from(move |e: E| {
             let f = f.clone();
             bridge.borrow_mut().send_service(ServiceRequest::Reduce({
-                let f = f.clone();
                 Box::new(move |state| {
                     f(state, e);
                 })
@@ -186,7 +185,6 @@ pub trait Dispatcher {
             bridge
                 .borrow_mut()
                 .send_service(ServiceRequest::Future(Box::pin({
-                    let this = this.clone();
                     let f = f.clone();
                     async move {
                         f(this).await;
@@ -211,7 +209,6 @@ pub trait Dispatcher {
             bridge
                 .borrow_mut()
                 .send_service(ServiceRequest::Future(Box::pin({
-                    let this = this.clone();
                     let f = f.clone();
                     async move {
                         f(this, e).await;
@@ -229,7 +226,7 @@ pub trait Dispatcher {
         E: 'static,
     {
         let this = self.clone();
-        let bridge = this.bridge().clone();
+        let bridge = this.bridge();
         Callback::once(move |_| {
             bridge
                 .borrow_mut()
@@ -250,7 +247,7 @@ pub trait Dispatcher {
         E: 'static,
     {
         let this = self.clone();
-        let bridge = this.bridge().clone();
+        let bridge = this.bridge();
         Callback::once(move |e| {
             bridge
                 .borrow_mut()
@@ -355,6 +352,7 @@ pub struct DispatchProps<STORE: Store, SCOPE: 'static = STORE> {
 }
 
 impl<STORE: Store, SCOPE: 'static> DispatchProps<STORE, SCOPE> {
+    #[allow(unused)]
     pub(crate) fn new(on_state: Callback<Rc<STORE::Model>>) -> Self {
         Self {
             state: Default::default(),
@@ -364,8 +362,7 @@ impl<STORE: Store, SCOPE: 'static> DispatchProps<STORE, SCOPE> {
 
     pub fn state(&self) -> Rc<Model<STORE>> {
         Rc::clone(
-            &self
-                .state
+            self.state
                 .borrow()
                 .as_ref()
                 .expect("State accessed prematurely. Missing WithDispatch?"),
@@ -436,22 +433,23 @@ where
 /// # Example
 ///
 /// ```
-/// # #[derive(Clone)]
+/// # #[derive(Clone, Default)]
 /// # struct MyState;
-///     
+/// # use yew::Properties;
+/// # use yewdux::prelude::*;
+///
 /// #[derive(Clone, PartialEq, Properties)]
 /// struct Props {
 ///     dispatch: DispatchProps<BasicStore<MyState>>,
 /// }
 ///
-/// impl Dispatched for Props {
+/// impl WithDispatchProps for Props {
 ///     type Store = BasicStore<MyState>;
 ///
 ///     fn dispatch(&self) -> &DispatchProps<Self::Store> {
 ///         &self.dispatch
 ///     }
 /// }
-
 pub trait WithDispatchProps {
     type Store: Store;
 

--- a/yewdux/src/lib.rs
+++ b/yewdux/src/lib.rs
@@ -9,7 +9,7 @@
 //! component or agent, live for entire application lifetime, and are clone-on-write by default.
 //!
 //! ## Example
-//! ```
+//! ```no_run
 //! use std::rc::Rc;
 //!
 //! use yew::prelude::*;
@@ -35,13 +35,13 @@
 //!     type Message = Msg;
 //!     type Properties = ();
 //!
-//!     fn create(_props: Self::Properties, link: ComponentLink<Self>) -> Self {
+//!     fn create(ctx: &Context<Self>) -> Self {
 //!         // Create Dispatch with a bridge that receives new state.
-//!         let dispatch = Dispatch::bridge_state(link.callback(Msg::State));
+//!         let dispatch = Dispatch::bridge_state(ctx.link().callback(Msg::State));
 //!         // Magically increment our counter for this example.
 //!         // NOTE: Changes aren't immediate! We won't see new state until we receive it in our update
 //!         // method.
-//!         dispatch.reduce(|s| s.count += 1);
+//!         dispatch.reduce(|s: &mut State| s.count += 1);
 //!
 //!         Self {
 //!             dispatch,
@@ -49,7 +49,7 @@
 //!         }
 //!     }
 //!
-//!     fn update(&mut self, msg: Self::Message) -> ShouldRender {
+//!     fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
 //!         match msg {
 //!             Msg::State(state) => {
 //!                 // Receive new state and re-render.
@@ -59,19 +59,15 @@
 //!         }
 //!     }
 //!
-//!     fn change(&mut self, _props: Self::Properties) -> ShouldRender {
-//!         false
-//!     }
-//!
-//!     fn view(&self) -> Html {
+//!     fn view(&self, _ctx: &Context<Self>) -> Html {
 //!         let count = self.state.count;
 //!         // We can modify state with callbacks too!
-//!         let incr = self.dispatch.reduce_callback(|s| s.count += 1);
+//!         let onclick = self.dispatch.reduce_callback(|s| s.count += 1);
 //!
 //!         html! {
 //!             <>
 //!             <h1>{ count }</h1>
-//!             <button onclick=incr>{"+1"}</button>
+//!             <button {onclick}>{"+1"}</button>
 //!             </>
 //!         }
 //!     }
@@ -82,6 +78,7 @@
 //!     yew::start_app::<App>();
 //! }
 //! ```
+#![allow(clippy::needless_doctest_main)]
 
 pub mod component;
 pub mod dispatch;

--- a/yewdux/src/store/persistent.rs
+++ b/yewdux/src/store/persistent.rs
@@ -3,7 +3,6 @@ use std::rc::Rc;
 
 use serde::{Deserialize, Serialize};
 use web_sys::Storage;
-use yew::utils::window;
 
 use super::{Store, StoreLink};
 
@@ -39,7 +38,7 @@ where
 {
     pub fn new() -> Self {
         let mut this: Self = Default::default();
-        let window = window();
+        let window = web_sys::window().expect("no window available");
         this.storage = match T::area() {
             Area::Local => window.local_storage().ok().flatten(),
             Area::Session => window.session_storage().ok().flatten(),


### PR DESCRIPTION
Hi,
in current master of yew, there are no longer yew::utils, so I've switched to web_sys window.
The first commit is the only what's needed in order to make yewdux compiling as a dependency.

The second commit is appliance of all cargo-clippy suggestions as well as making all doc examples without ignore to compile.