### PR TITLE
Fix functional component example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ use yewdux::prelude::*;
 use yewdux_functional::*;
 
 
-#[derive(function_component(MyComponent))]
+#[function_component(MyComponent)]
 fn my_component() -> Html {
     let store = use_store::<BasicStore<MyState>>();
     let onclick = store.dispatch().reduce_callback(|s| s.count += 1);


### PR DESCRIPTION
`function_component` is a macro, not a derivable trait. This just fixes the docs to have this correct.