### PR TITLE
Fix Checkbox not supporting persistence

### DIFF
--- a/crates/yewdux-input/Cargo.toml
+++ b/crates/yewdux-input/Cargo.toml
@@ -11,3 +11,4 @@ web-sys = "0.3"
 wasm-bindgen = "0.2"
 yew = { git = "https://github.com/yewstack/yew.git" }
 chrono = "0.4.22"
+serde = { version = "1.0.114", features = ["rc"] }

--- a/crates/yewdux-input/src/lib.rs
+++ b/crates/yewdux-input/src/lib.rs
@@ -4,6 +4,7 @@ use wasm_bindgen::JsCast;
 use web_sys::{HtmlInputElement, HtmlTextAreaElement};
 use yew::prelude::*;
 use yewdux::prelude::*;
+use serde::{Deserialize, Serialize};
 
 pub enum InputElement {
     Input(HtmlInputElement),
@@ -26,7 +27,7 @@ where
     }
 }
 
-#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct Checkbox(bool);
 
 impl Checkbox {


### PR DESCRIPTION
When using `#[store(storage = "local")]` with the `Checkbox` type the build fails because it does not support serialization.

To check whether it works I just quickly changed the input example and added the `#[store]` macro, which worked with trunk. I didn't actually check whether persistence worked.

I chose the exact same version/featureset of serde as yewdux itself depends on, hope that is a good idea.