### PR TITLE
Add support for scoped contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,33 @@ See the [book](https://intendednull.github.io/yewdux/) for more details.
 use yew::prelude::*;
 use yewdux::prelude::*;
 
-#[derive(Default, Clone, PartialEq, Eq, Store)]
+#[derive(Debug, Default, Clone, PartialEq, Store)]
 struct State {
     count: u32,
 }
 
 #[function_component]
-fn App() -> Html {
-    let (state, dispatch) = use_store::<State>();
-    let onclick = dispatch.reduce_mut_callback(|state| state.count += 1);
+fn ViewCount() -> Html {
+    let (state, _) = use_store::<State>();
+    html!(state.count)
+}
+
+#[function_component]
+fn IncrementCount() -> Html {
+    let (_, dispatch) = use_store::<State>();
+    let onclick = dispatch.reduce_mut_callback(|counter| counter.count += 1);
 
     html! {
-        <>
-        <p>{ state.count }</p>
         <button {onclick}>{"+1"}</button>
+    }
+}
+
+#[function_component]
+fn App() -> Html {
+    html! {
+        <>
+        <ViewCount />
+        <IncrementCount />
         </>
     }
 }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See the [book](https://intendednull.github.io/yewdux/) for more details.
 use yew::prelude::*;
 use yewdux::prelude::*;
 
-#[derive(Debug, Default, Clone, PartialEq, Store)]
+#[derive(Default, Clone, PartialEq, Store)]
 struct State {
     count: u32,
 }

--- a/crates/yewdux-input/src/lib.rs
+++ b/crates/yewdux-input/src/lib.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use wasm_bindgen::JsCast;
 use web_sys::{HtmlInputElement, HtmlTextAreaElement};
 use yew::prelude::*;
-use yewdux::prelude::*;
+use yewdux::{prelude::*, Context};
 
 pub enum InputElement {
     Input(HtmlInputElement),
@@ -47,13 +47,13 @@ impl FromInputElement for Checkbox {
 }
 
 pub trait InputDispatch<S: Store> {
-    fn input<F, E, R>(&self, f: F) -> Callback<E>
+    fn input<F, E, R>(&self, f: F, cx: &Context) -> Callback<E>
     where
         R: FromInputElement,
         F: Fn(Rc<S>, R) -> Rc<S> + 'static,
         E: AsRef<Event> + JsCast + 'static,
     {
-        Dispatch::<S>::new().reduce_callback_with(move |s, e| {
+        Dispatch::<S>::with_cx(cx).reduce_callback_with(move |s, e| {
             if let Some(value) = input_value(e) {
                 f(s, value)
             } else {
@@ -62,14 +62,14 @@ pub trait InputDispatch<S: Store> {
         })
     }
 
-    fn input_mut<F, E, R>(&self, f: F) -> Callback<E>
+    fn input_mut<F, E, R>(&self, f: F, cx: &Context) -> Callback<E>
     where
         S: Clone,
         R: FromInputElement,
         F: Fn(&mut S, R) + 'static,
         E: AsRef<Event> + JsCast + 'static,
     {
-        Dispatch::<S>::new().reduce_mut_callback_with(move |s, e| {
+        Dispatch::<S>::with_cx(cx).reduce_mut_callback_with(move |s, e| {
             if let Some(value) = input_value(e) {
                 f(s, value);
             }

--- a/crates/yewdux-input/src/lib.rs
+++ b/crates/yewdux-input/src/lib.rs
@@ -83,7 +83,7 @@ pub trait InputDispatch<S: Store> {
 
 impl<S: Store> InputDispatch<S> for Dispatch<S> {
     fn context(&self) -> &Context {
-        self.context()
+        self.cx()
     }
 }
 

--- a/crates/yewdux-input/src/lib.rs
+++ b/crates/yewdux-input/src/lib.rs
@@ -1,10 +1,10 @@
 use std::{rc::Rc, str::FromStr};
 
+use serde::{Deserialize, Serialize};
 use wasm_bindgen::JsCast;
 use web_sys::{HtmlInputElement, HtmlTextAreaElement};
 use yew::prelude::*;
 use yewdux::prelude::*;
-use serde::{Deserialize, Serialize};
 
 pub enum InputElement {
     Input(HtmlInputElement),
@@ -53,7 +53,7 @@ pub trait InputDispatch<S: Store> {
         F: Fn(Rc<S>, R) -> Rc<S> + 'static,
         E: AsRef<Event> + JsCast + 'static,
     {
-        Dispatch::<S>::new().reduce_callback_with(move |s, e| {
+        Dispatch::<S>::global().reduce_callback_with(move |s, e| {
             if let Some(value) = input_value(e) {
                 f(s, value)
             } else {
@@ -69,7 +69,7 @@ pub trait InputDispatch<S: Store> {
         F: Fn(&mut S, R) + 'static,
         E: AsRef<Event> + JsCast + 'static,
     {
-        Dispatch::<S>::new().reduce_mut_callback_with(move |s, e| {
+        Dispatch::<S>::global().reduce_mut_callback_with(move |s, e| {
             if let Some(value) = input_value(e) {
                 f(s, value);
             }

--- a/crates/yewdux-input/src/lib.rs
+++ b/crates/yewdux-input/src/lib.rs
@@ -83,7 +83,7 @@ pub trait InputDispatch<S: Store> {
 
 impl<S: Store> InputDispatch<S> for Dispatch<S> {
     fn context(&self) -> &Context {
-        self.cx()
+        self.context()
     }
 }
 

--- a/crates/yewdux-input/src/lib.rs
+++ b/crates/yewdux-input/src/lib.rs
@@ -53,7 +53,7 @@ pub trait InputDispatch<S: Store> {
         F: Fn(Rc<S>, R) -> Rc<S> + 'static,
         E: AsRef<Event> + JsCast + 'static,
     {
-        Dispatch::<S>::global().reduce_callback_with(move |s, e| {
+        Dispatch::<S>::new().reduce_callback_with(move |s, e| {
             if let Some(value) = input_value(e) {
                 f(s, value)
             } else {
@@ -69,7 +69,7 @@ pub trait InputDispatch<S: Store> {
         F: Fn(&mut S, R) + 'static,
         E: AsRef<Event> + JsCast + 'static,
     {
-        Dispatch::<S>::global().reduce_mut_callback_with(move |s, e| {
+        Dispatch::<S>::new().reduce_mut_callback_with(move |s, e| {
             if let Some(value) = input_value(e) {
                 f(s, value);
             }

--- a/crates/yewdux-input/src/lib.rs
+++ b/crates/yewdux-input/src/lib.rs
@@ -56,7 +56,7 @@ pub trait InputDispatch<S: Store> {
         E: AsRef<Event> + JsCast + 'static,
     {
         let cx = self.context();
-        Dispatch::<S>::with_cx(cx).reduce_callback_with(move |s, e| {
+        Dispatch::<S>::new(cx).reduce_callback_with(move |s, e| {
             if let Some(value) = input_value(e) {
                 f(s, value)
             } else {
@@ -73,7 +73,7 @@ pub trait InputDispatch<S: Store> {
         E: AsRef<Event> + JsCast + 'static,
     {
         let cx = self.context();
-        Dispatch::<S>::with_cx(cx).reduce_mut_callback_with(move |s, e| {
+        Dispatch::<S>::new(cx).reduce_mut_callback_with(move |s, e| {
             if let Some(value) = input_value(e) {
                 f(s, value);
             }

--- a/crates/yewdux-macros/src/store.rs
+++ b/crates/yewdux-macros/src/store.rs
@@ -40,7 +40,8 @@ pub(crate) fn derive(input: DeriveInput) -> TokenStream {
                 #[cfg(target_arch = "wasm32")]
                 fn new() -> Self {
                     ::yewdux::listener::init_listener(
-                        ::yewdux::storage::StorageListener::<Self>::new(#area)
+                        ::yewdux::storage::StorageListener::<Self>::new(#area),
+                        &::yewdux::context::Context::global()
                     );
 
                     #sync

--- a/crates/yewdux-macros/src/store.rs
+++ b/crates/yewdux-macros/src/store.rs
@@ -72,7 +72,7 @@ pub(crate) fn derive(input: DeriveInput) -> TokenStream {
                 }
 
                 #[cfg(not(target_arch = "wasm32"))]
-                fn new(_cx: &::yewdux::Context) -> Self {
+                fn new(cx: &::yewdux::Context) -> Self {
                     #(#extra_listeners)*
                     Default::default()
                 }

--- a/crates/yewdux-macros/src/store.rs
+++ b/crates/yewdux-macros/src/store.rs
@@ -28,7 +28,7 @@ pub(crate) fn derive(input: DeriveInput) -> TokenStream {
 
             let sync = if opts.storage_tab_sync {
                 quote! {
-                    if let Err(err) = ::yewdux::storage::init_tab_sync::<Self>(#area) {
+                    if let Err(err) = ::yewdux::storage::init_tab_sync::<Self>(#area, cx) {
                         ::yewdux::log::error!("Unable to init tab sync for storage: {:?}", err);
                     }
                 }
@@ -38,10 +38,10 @@ pub(crate) fn derive(input: DeriveInput) -> TokenStream {
 
             quote! {
                 #[cfg(target_arch = "wasm32")]
-                fn new() -> Self {
+                fn new(cx: &::yewdux::Context) -> Self {
                     ::yewdux::listener::init_listener(
                         ::yewdux::storage::StorageListener::<Self>::new(#area),
-                        &::yewdux::context::Context::global()
+                        cx
                     );
 
                     #sync
@@ -58,13 +58,13 @@ pub(crate) fn derive(input: DeriveInput) -> TokenStream {
                 }
 
                 #[cfg(not(target_arch = "wasm32"))]
-                fn new() -> Self {
+                fn new(_cx: &::yewdux::Context) -> Self {
                     Default::default()
                 }
             }
         }
         None => quote! {
-            fn new() -> Self {
+            fn new(_cx: &::yewdux::Context) -> Self {
                 Default::default()
             }
         },

--- a/crates/yewdux-macros/src/store.rs
+++ b/crates/yewdux-macros/src/store.rs
@@ -79,7 +79,7 @@ pub(crate) fn derive(input: DeriveInput) -> TokenStream {
             }
         }
         None => quote! {
-            fn new(_cx: &::yewdux::Context) -> Self {
+            fn new(cx: &::yewdux::Context) -> Self {
                 #(#extra_listeners)*
                 Default::default()
             }

--- a/crates/yewdux-utils/src/lib.rs
+++ b/crates/yewdux-utils/src/lib.rs
@@ -25,7 +25,7 @@ impl<T: Store + PartialEq> Listener for HistoryListener<T> {
     type Store = T;
 
     fn on_change(&mut self, cx: &Context, state: Rc<Self::Store>) {
-        Dispatch::<HistoryStore<T>>::with_cx(cx).apply(HistoryChangeMessage::<T>(state))
+        Dispatch::<HistoryStore<T>>::new(cx).apply(HistoryChangeMessage::<T>(state))
     }
 }
 
@@ -76,7 +76,7 @@ impl<T: Store + PartialEq> HistoryStore<T> {
 
 impl<T: Store + PartialEq> Store for HistoryStore<T> {
     fn new(cx: &Context) -> Self {
-        let dispatch = Dispatch::<T>::with_cx(cx);
+        let dispatch = Dispatch::<T>::new(cx);
         let s1 = dispatch.get();
         Self {
             vector: vec![s1],

--- a/crates/yewdux-utils/src/lib.rs
+++ b/crates/yewdux-utils/src/lib.rs
@@ -1,5 +1,5 @@
 use std::{marker::PhantomData, rc::Rc};
-use yewdux::{prelude::*, Context, dispatch};
+use yewdux::{prelude::*, Context};
 
 #[derive(Default)]
 pub struct HistoryListener<T: Store + PartialEq>(PhantomData<T>);
@@ -74,7 +74,7 @@ impl<T: Store + PartialEq> HistoryStore<T> {
     }
 }
 
-impl <T: Store + PartialEq> Store for HistoryStore<T> {
+impl<T: Store + PartialEq> Store for HistoryStore<T> {
     fn new(cx: &Context) -> Self {
         let dispatch = Dispatch::<T>::with_cx(cx);
         let s1 = dispatch.get();

--- a/crates/yewdux-utils/src/lib.rs
+++ b/crates/yewdux-utils/src/lib.rs
@@ -25,7 +25,7 @@ impl<T: Store + PartialEq> Listener for HistoryListener<T> {
     type Store = T;
 
     fn on_change(&mut self, cx: &Context, state: Rc<Self::Store>) {
-        Dispatch::<HistoryStore<T>>::new(cx).apply(HistoryChangeMessage::<T>(state))
+        Dispatch::<HistoryStore<T>>::with_cx(cx).apply(HistoryChangeMessage::<T>(state))
     }
 }
 
@@ -74,7 +74,7 @@ impl<T: Store + PartialEq> HistoryStore<T> {
 
 impl<T: Store + PartialEq> Default for HistoryStore<T> {
     fn default() -> Self {
-        let s1 = Dispatch::<T>::global().get();
+        let s1 = Dispatch::<T>::new().get();
         Self {
             vector: vec![s1],
             index: 0,
@@ -131,7 +131,7 @@ impl<T: Store + PartialEq + Clone> Reducer<HistoryStore<T>> for HistoryMessage {
         };
 
         if state_changed {
-            Dispatch::<T>::global().reduce(|_| mut_state.current().clone());
+            Dispatch::<T>::new().reduce(|_| mut_state.current().clone());
         }
 
         state

--- a/crates/yewdux/Cargo.toml
+++ b/crates/yewdux/Cargo.toml
@@ -14,6 +14,9 @@ categories = ["wasm", "web-programming", "rust-patterns"]
 default = ["future"]
 future = []
 
+# INTERNAL USE ONLY
+doctests = []
+
 [dependencies]
 anymap = "1.0.0-beta.2"
 async-trait = "0.1.58"

--- a/crates/yewdux/src/context.rs
+++ b/crates/yewdux/src/context.rs
@@ -70,7 +70,7 @@ impl Context {
         Default::default()
     }
 
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(any(doc, feature = "doctests", target_arch = "wasm32"))]
     pub fn global() -> Self {
         thread_local! {
             static CONTEXT: Context = Default::default();

--- a/crates/yewdux/src/context.rs
+++ b/crates/yewdux/src/context.rs
@@ -70,6 +70,7 @@ impl Context {
         Default::default()
     }
 
+    #[cfg(target_arch = "wasm32")]
     pub fn global() -> Self {
         thread_local! {
             static CONTEXT: Context = Default::default();

--- a/crates/yewdux/src/context.rs
+++ b/crates/yewdux/src/context.rs
@@ -58,7 +58,7 @@ impl<S: Store> Entry<S> {
 /// struct Counter(usize);
 ///
 /// let cx = yewdux::Context::new();
-/// let dispatch = Dispatch::<Counter>::with_context(&cx);
+/// let dispatch = Dispatch::<Counter>::new(&cx);
 /// ```
 #[derive(Clone, Default, PartialEq)]
 pub struct Context {

--- a/crates/yewdux/src/context.rs
+++ b/crates/yewdux/src/context.rs
@@ -96,7 +96,7 @@ impl Context {
                 .clone()
         });
 
-        // If it doesn't exist, create and save the new store (no pun intended).
+        // If it doesn't exist, create and save the new store.
         let exists = maybe_entry.borrow().is_some();
         if !exists {
             // Init store outside of borrow. This allows the store to access other stores when it
@@ -117,7 +117,6 @@ impl Context {
         entry
     }
 
-    /// Change state from a function.
     pub fn reduce<S: Store, R: Reducer<S>>(&self, r: R) {
         let entry = self.get_or_init::<S>();
         let should_notify = entry.reduce(r);
@@ -143,7 +142,6 @@ impl Context {
         }
     }
 
-    /// Change state using a mutable reference from a function.
     pub fn reduce_mut<S: Store + Clone, F: FnOnce(&mut S)>(&self, f: F) {
         self.reduce(|mut state| {
             f(Rc::make_mut(&mut state));

--- a/crates/yewdux/src/context.rs
+++ b/crates/yewdux/src/context.rs
@@ -47,7 +47,7 @@ impl<S: Store> Entry<S> {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, PartialEq)]
 pub struct Context {
     inner: Mrc<AnyMap>,
 }

--- a/crates/yewdux/src/context.rs
+++ b/crates/yewdux/src/context.rs
@@ -221,8 +221,8 @@ mod tests {
     #[derive(Clone, PartialEq, Eq)]
     struct TestState2(u32);
     impl Store for TestState2 {
-        fn new(_cx: &Context) -> Self {
-            Context::global().get_or_init::<TestState>();
+        fn new(cx: &Context) -> Self {
+            cx.get_or_init::<TestState>();
             Self(0)
         }
 
@@ -233,7 +233,7 @@ mod tests {
 
     #[test]
     fn can_access_other_store_for_new_of_current_store() {
-        let _context = Context::global().get_or_init::<TestState2>();
+        let _context = Context::new().get_or_init::<TestState2>();
     }
 
     #[derive(Clone, PartialEq, Eq)]
@@ -259,9 +259,10 @@ mod tests {
 
     #[test]
     fn store_new_is_only_called_once() {
-        Context::global().get_or_init::<StoreNewIsOnlyCalledOnce>();
-        let context = Context::global().get_or_init::<StoreNewIsOnlyCalledOnce>();
+        let cx = Context::new();
+        cx.get_or_init::<StoreNewIsOnlyCalledOnce>();
+        let entry = cx.get_or_init::<StoreNewIsOnlyCalledOnce>();
 
-        assert!(context.store.borrow().0.get() == 1)
+        assert!(entry.store.borrow().0.get() == 1)
     }
 }

--- a/crates/yewdux/src/context.rs
+++ b/crates/yewdux/src/context.rs
@@ -101,7 +101,7 @@ impl Context {
             // Init store outside of borrow. This allows the store to access other stores when it
             // is being created.
             let entry = Entry {
-                store: Mrc::new(Rc::new(S::new())),
+                store: Mrc::new(Rc::new(S::new(self))),
             };
 
             *maybe_entry.borrow_mut() = Some(entry);
@@ -208,7 +208,7 @@ mod tests {
     #[derive(Clone, PartialEq, Eq)]
     struct TestState(u32);
     impl Store for TestState {
-        fn new() -> Self {
+        fn new(_cx: &Context) -> Self {
             Self(0)
         }
 
@@ -220,7 +220,7 @@ mod tests {
     #[derive(Clone, PartialEq, Eq)]
     struct TestState2(u32);
     impl Store for TestState2 {
-        fn new() -> Self {
+        fn new(_cx: &Context) -> Self {
             Context::global().get_or_init::<TestState>();
             Self(0)
         }
@@ -238,7 +238,7 @@ mod tests {
     #[derive(Clone, PartialEq, Eq)]
     struct StoreNewIsOnlyCalledOnce(Rc<Cell<u32>>);
     impl Store for StoreNewIsOnlyCalledOnce {
-        fn new() -> Self {
+        fn new(_cx: &Context) -> Self {
             thread_local! {
                 /// Stores all shared state.
                 static COUNT: Rc<Cell<u32>> = Default::default();

--- a/crates/yewdux/src/context.rs
+++ b/crates/yewdux/src/context.rs
@@ -1,17 +1,20 @@
 use std::rc::Rc;
+#[cfg(feature = "future")]
+use std::{future::Future, pin::Pin};
 
 use anymap::AnyMap;
 
 use crate::{
     mrc::Mrc,
     store::{AsyncReducer, Reducer, Store},
+    subscriber::{Callable, SubscriberId, Subscribers},
 };
 
-pub(crate) struct Context<S> {
+pub(crate) struct Entry<S> {
     pub(crate) store: Mrc<Rc<S>>,
 }
 
-impl<S> Clone for Context<S> {
+impl<S> Clone for Entry<S> {
     fn clone(&self) -> Self {
         Self {
             store: Mrc::clone(&self.store),
@@ -19,7 +22,7 @@ impl<S> Clone for Context<S> {
     }
 }
 
-impl<S: Store> Context<S> {
+impl<S: Store> Entry<S> {
     /// Apply a function to state, returning if it should notify subscribers or not.
     pub(crate) fn reduce<R: Reducer<S>>(&self, reducer: R) -> bool {
         let old = Rc::clone(&self.store.borrow());
@@ -44,49 +47,143 @@ impl<S: Store> Context<S> {
     }
 }
 
-pub(crate) fn get_or_init<S: Store>() -> Context<S> {
-    thread_local! {
-        /// Holds all shared state.
-        static CONTEXTS: Mrc<AnyMap> = Mrc::new(AnyMap::new());
+#[derive(Clone, Default)]
+pub struct Context {
+    inner: Mrc<AnyMap>,
+}
+
+impl Context {
+    pub fn new() -> Self {
+        Default::default()
     }
 
-    let contexts = CONTEXTS
-        .try_with(|contexts| contexts.clone())
-        .expect("CONTEXTS thread local key init failed");
+    pub fn global() -> Self {
+        thread_local! {
+            static CONTEXTS: Context = Default::default();
+        }
 
-    // Get context, or None if it doesn't exist.
-    //
-    // We use an option here because a new Store should not be created during this borrow. We want
-    // to allow this store access to other stores during creation, so cannot be borrowing the
-    // global resource while initializing. Instead we create a temporary placeholder, which
-    // indicates the store needs to be created. Without this indicator we would have needed to
-    // check if the map contains the entry beforehand, which would have meant two map lookups per
-    // call instead of just one.
-    let maybe_context = contexts.with_mut(|x| {
-        x.entry::<Mrc<Option<Context<S>>>>()
-            .or_insert_with(|| None.into())
+        CONTEXTS
+            .try_with(|contexts| contexts.clone())
+            .expect("CONTEXTS thread local key init failed")
+    }
+
+    pub(crate) fn get_or_init<S: Store>(&self) -> Entry<S> {
+        // Get context, or None if it doesn't exist.
+        //
+        // We use an option here because a new Store should not be created during this borrow. We want
+        // to allow this store access to other stores during creation, so cannot be borrowing the
+        // global resource while initializing. Instead we create a temporary placeholder, which
+        // indicates the store needs to be created. Without this indicator we would have needed to
+        // check if the map contains the entry beforehand, which would have meant two map lookups per
+        // call instead of just one.
+        let maybe_entry = self.inner.with_mut(|x| {
+            x.entry::<Mrc<Option<Entry<S>>>>()
+                .or_insert_with(|| None.into())
+                .clone()
+        });
+
+        // If it doesn't exist, create and store the context (no pun intended).
+        let exists = maybe_entry.borrow().is_some();
+        if !exists {
+            // Init context outside of borrow. This allows the store to access other stores when it is
+            // being created.
+            let entry = Entry {
+                store: Mrc::new(Rc::new(S::new())),
+            };
+
+            *maybe_entry.borrow_mut() = Some(entry);
+        }
+
+        // Now we get the context, which must be initialized because we already checked above.
+        let entry = maybe_entry
+            .borrow()
             .clone()
-    });
+            .expect("Context not initialized");
 
-    // If it doesn't exist, create and store the context (no pun intended).
-    let exists = maybe_context.borrow().is_some();
-    if !exists {
-        // Init context outside of borrow. This allows the store to access other stores when it is
-        // being created.
-        let context = Context {
-            store: Mrc::new(Rc::new(S::new())),
-        };
-
-        *maybe_context.borrow_mut() = Some(context);
+        entry
     }
 
-    // Now we get the context, which must be initialized because we already checked above.
-    let context = maybe_context
-        .borrow()
-        .clone()
-        .expect("Context not initialized");
+    /// Change state from a function.
+    pub fn reduce<S: Store, R: Reducer<S>>(&self, r: R) {
+        let entry = self.get_or_init::<S>();
+        let should_notify = entry.reduce(r);
 
-    context
+        if should_notify {
+            let state = Rc::clone(&entry.store.borrow());
+            self.notify_subscribers(state)
+        }
+    }
+
+    #[cfg(feature = "future")]
+    pub async fn reduce_future<S, R>(&self, r: R)
+    where
+        S: Store,
+        R: AsyncReducer<S>,
+    {
+        let entry = self.get_or_init::<S>();
+        let should_notify = entry.reduce_future(r).await;
+
+        if should_notify {
+            let state = Rc::clone(&entry.store.borrow());
+            self.notify_subscribers(state)
+        }
+    }
+
+    /// Change state using a mutable reference from a function.
+    pub fn reduce_mut<S: Store + Clone, F: FnOnce(&mut S)>(&self, f: F) {
+        self.reduce(|mut state| {
+            f(Rc::make_mut(&mut state));
+            state
+        });
+    }
+
+    #[cfg(feature = "future")]
+    pub async fn reduce_mut_future<S, R, F>(&self, f: F)
+    where
+        S: Store + Clone,
+        F: FnOnce(&mut S) -> Pin<Box<dyn Future<Output = R> + '_>>,
+    {
+        self.reduce_future(|mut state| async move {
+            f(Rc::make_mut(&mut state)).await;
+            state
+        })
+        .await;
+    }
+
+    /// Set state to given value.
+    pub fn set<S: Store>(&self, value: S) {
+        self.reduce(move |_| value.into());
+    }
+
+    /// Get current state.
+    pub fn get<S: Store>(&self) -> Rc<S> {
+        Rc::clone(&self.get_or_init::<S>().store.borrow())
+    }
+
+    /// Send state to all subscribers.
+    pub fn notify_subscribers<S: Store>(&self, state: Rc<S>) {
+        let entry = self.get_or_init::<Mrc<Subscribers<S>>>();
+        entry.store.borrow().notify(state);
+    }
+
+    /// Subscribe to a store. `on_change` is called immediately, then every  time state changes.
+    pub fn subscribe<S: Store, N: Callable<S>>(&self, on_change: N) -> SubscriberId<S> {
+        // Notify subscriber with inital state.
+        on_change.call(self.get::<S>());
+
+        self.get_or_init::<Mrc<Subscribers<S>>>()
+            .store
+            .borrow()
+            .subscribe(on_change)
+    }
+
+    /// Similar to [Self::subscribe], however state is not called immediately.
+    pub fn subscribe_silent<S: Store, N: Callable<S>>(&self, on_change: N) -> SubscriberId<S> {
+        self.get_or_init::<Mrc<Subscribers<S>>>()
+            .store
+            .borrow()
+            .subscribe(on_change)
+    }
 }
 
 #[cfg(test)]
@@ -111,7 +208,7 @@ mod tests {
     struct TestState2(u32);
     impl Store for TestState2 {
         fn new() -> Self {
-            get_or_init::<TestState>();
+            Context::global().get_or_init::<TestState>();
             Self(0)
         }
 
@@ -122,7 +219,7 @@ mod tests {
 
     #[test]
     fn can_access_other_store_for_new_of_current_store() {
-        let _context = get_or_init::<TestState2>();
+        let _context = Context::global().get_or_init::<TestState2>();
     }
 
     #[derive(Clone, PartialEq, Eq)]
@@ -148,8 +245,8 @@ mod tests {
 
     #[test]
     fn store_new_is_only_called_once() {
-        get_or_init::<StoreNewIsOnlyCalledOnce>();
-        let context = get_or_init::<StoreNewIsOnlyCalledOnce>();
+        Context::global().get_or_init::<StoreNewIsOnlyCalledOnce>();
+        let context = Context::global().get_or_init::<StoreNewIsOnlyCalledOnce>();
 
         assert!(context.store.borrow().0.get() == 1)
     }

--- a/crates/yewdux/src/context.rs
+++ b/crates/yewdux/src/context.rs
@@ -1,4 +1,4 @@
-use std::{borrow::BorrowMut, rc::Rc};
+use std::rc::Rc;
 #[cfg(feature = "future")]
 use std::{future::Future, pin::Pin};
 
@@ -10,27 +10,14 @@ use crate::{
     subscriber::{Callable, SubscriberId, Subscribers},
 };
 
-#[allow(unused_variables)]
-fn check_arch(is_global: bool) {
-    #[cfg(not(target_arch = "wasm32"))]
-    if is_global {
-        panic!(concat!(
-            "Writing to global context outside of the browser is unsafe.",
-            " Please use a context provider like YewduxRoot",
-        ))
-    }
-}
-
 pub(crate) struct Entry<S> {
     pub(crate) store: Mrc<Rc<S>>,
-    is_global: bool,
 }
 
 impl<S> Clone for Entry<S> {
     fn clone(&self) -> Self {
         Self {
             store: Mrc::clone(&self.store),
-            is_global: self.is_global,
         }
     }
 }
@@ -38,8 +25,6 @@ impl<S> Clone for Entry<S> {
 impl<S: Store> Entry<S> {
     /// Apply a function to state, returning if it should notify subscribers or not.
     pub(crate) fn reduce<R: Reducer<S>>(&self, reducer: R) -> bool {
-        check_arch(self.is_global);
-
         let old = Rc::clone(&self.store.borrow());
         // Apply the reducer.
         let new = reducer.apply(Rc::clone(&old));
@@ -52,8 +37,6 @@ impl<S: Store> Entry<S> {
     /// Apply a future reduction to state, returning if it should notify subscribers or not.
     #[cfg(feature = "future")]
     pub(crate) async fn reduce_future<R: AsyncReducer<S>>(&self, reducer: R) -> bool {
-        check_arch(self.is_global);
-
         let old = Rc::clone(&self.store.borrow());
         // Apply the reducer.
         let new = reducer.apply(Rc::clone(&old)).await;
@@ -80,7 +63,6 @@ impl<S: Store> Entry<S> {
 #[derive(Clone, Default, PartialEq)]
 pub struct Context {
     inner: Mrc<AnyMap>,
-    is_global: bool,
 }
 
 impl Context {
@@ -93,13 +75,9 @@ impl Context {
             static CONTEXT: Context = Default::default();
         }
 
-        let mut cx = CONTEXT
+        CONTEXT
             .try_with(|cx| cx.clone())
-            .expect("CONTEXTS thread local key init failed");
-        // Mark as global, for safety check later.
-        cx.borrow_mut().is_global = true;
-
-        cx
+            .expect("CONTEXTS thread local key init failed")
     }
 
     pub(crate) fn get_or_init<S: Store>(&self) -> Entry<S> {
@@ -124,7 +102,6 @@ impl Context {
             // is being created.
             let entry = Entry {
                 store: Mrc::new(Rc::new(S::new())),
-                is_global: self.is_global,
             };
 
             *maybe_entry.borrow_mut() = Some(entry);
@@ -285,12 +262,5 @@ mod tests {
         let context = Context::global().get_or_init::<StoreNewIsOnlyCalledOnce>();
 
         assert!(context.store.borrow().0.get() == 1)
-    }
-
-    #[test]
-    #[cfg_attr(not(target_arch = "wasm32"), should_panic)]
-    fn global_fails_without_wasm() {
-        let cx = Context::global();
-        cx.set(TestState(1));
     }
 }

--- a/crates/yewdux/src/context_provider.rs
+++ b/crates/yewdux/src/context_provider.rs
@@ -1,0 +1,18 @@
+use yew::prelude::*;
+
+use crate::context;
+
+#[derive(PartialEq, Clone, Properties)]
+pub struct Props {
+    pub children: Children,
+}
+
+#[function_component]
+pub fn YewduxRoot(Props { children }: &Props) -> Html {
+    let ctx = use_state(context::Context::new);
+    html! {
+        <ContextProvider<context::Context> context={(*ctx).clone()}>
+            { children }
+        </ContextProvider<context::Context>>
+    }
+}

--- a/crates/yewdux/src/dispatch.rs
+++ b/crates/yewdux/src/dispatch.rs
@@ -43,6 +43,13 @@ impl<S: Store> std::fmt::Debug for Dispatch<S> {
     }
 }
 
+#[cfg(target_arch = "wasm32")]
+impl<S: Store> Default for Dispatch<S> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<S: Store> Dispatch<S> {
     /// Create a new dispatch with the global context (thread local).
     #[cfg(target_arch = "wasm32")]
@@ -56,6 +63,11 @@ impl<S: Store> Dispatch<S> {
             _subscriber_id: Default::default(),
             context: cx.clone(),
         }
+    }
+
+    /// Get the context used by this dispatch.
+    pub fn context(&self) -> &Context {
+        &self.context
     }
 
     /// Create a dispatch that subscribes to changes in state. Latest state is sent immediately,
@@ -1189,9 +1201,8 @@ mod tests {
 
         let _id = {
             let flag = flag.clone();
-            Dispatch::<TestState>::with_cx(&cx).subscribe(
-                move |_| flag.clone().with_mut(|flag| *flag = true),
-            )
+            Dispatch::<TestState>::with_cx(&cx)
+                .subscribe(move |_| flag.clone().with_mut(|flag| *flag = true))
         };
 
         *flag.borrow_mut() = false;

--- a/crates/yewdux/src/dispatch.rs
+++ b/crates/yewdux/src/dispatch.rs
@@ -56,11 +56,11 @@ impl<S: Store> Dispatch<S> {
     /// This is only available for wasm32 targets. For SSR, see the YewduxRoot pattern.
     #[cfg(target_arch = "wasm32")]
     pub fn global() -> Self {
-        Self::with_cx(&Context::global())
+        Self::new(&Context::global())
     }
 
     /// Create a new dispatch with access to the given context.
-    pub fn with_cx(cx: &Context) -> Self {
+    pub fn new(cx: &Context) -> Self {
         Self {
             _subscriber_id: Default::default(),
             cx: cx.clone(),
@@ -860,12 +860,12 @@ mod tests {
 
     #[test]
     fn apply_no_clone() {
-        Dispatch::with_cx(&Context::new()).reduce(|_| TestStateNoClone(1).into());
+        Dispatch::new(&Context::new()).reduce(|_| TestStateNoClone(1).into());
     }
 
     #[test]
     fn reduce_changes_value() {
-        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
+        let dispatch = Dispatch::<TestState>::new(&Context::new());
 
         let old = dispatch.get();
 
@@ -880,7 +880,7 @@ mod tests {
     #[async_std::test]
     async fn reduce_future_changes_value() {
         let cx = Context::new();
-        let dispatch = Dispatch::<TestState>::with_cx(&cx);
+        let dispatch = Dispatch::<TestState>::new(&cx);
         let old = dispatch.get();
 
         dispatch
@@ -898,7 +898,7 @@ mod tests {
         use std::time::Duration;
 
         let cx = Context::new();
-        let dispatch = Dispatch::<TestState>::with_cx(&cx);
+        let dispatch = Dispatch::<TestState>::new(&cx);
 
         dispatch
             .reduce_future(|state| async move {
@@ -912,7 +912,7 @@ mod tests {
 
     #[test]
     fn reduce_mut_changes_value() {
-        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
+        let dispatch = Dispatch::<TestState>::new(&Context::new());
         let old = dispatch.get();
 
         dispatch.reduce_mut(|state| *state = TestState(1));
@@ -925,7 +925,7 @@ mod tests {
     #[cfg(feature = "future")]
     #[async_std::test]
     async fn reduce_mut_future_changes_value() {
-        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
+        let dispatch = Dispatch::<TestState>::new(&Context::new());
         let old = dispatch.get();
 
         dispatch
@@ -940,19 +940,19 @@ mod tests {
     #[test]
     fn reduce_does_not_require_static() {
         let val = "1".to_string();
-        Dispatch::with_cx(&Context::new()).reduce(|_| TestState(val.parse().unwrap()).into());
+        Dispatch::new(&Context::new()).reduce(|_| TestState(val.parse().unwrap()).into());
     }
 
     #[test]
     fn reduce_mut_does_not_require_static() {
         let val = "1".to_string();
-        Dispatch::with_cx(&Context::new())
+        Dispatch::new(&Context::new())
             .reduce_mut(|state: &mut TestState| state.0 = val.parse().unwrap());
     }
 
     #[test]
     fn set_changes_value() {
-        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
+        let dispatch = Dispatch::<TestState>::new(&Context::new());
 
         let old = dispatch.get();
 
@@ -965,7 +965,7 @@ mod tests {
 
     #[test]
     fn apply_changes_value() {
-        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
+        let dispatch = Dispatch::<TestState>::new(&Context::new());
         let old = dispatch.get();
 
         dispatch.apply(Msg);
@@ -977,7 +977,7 @@ mod tests {
 
     #[test]
     fn dispatch_set_works() {
-        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
+        let dispatch = Dispatch::<TestState>::new(&Context::new());
         let old = dispatch.get();
 
         dispatch.set(TestState(1));
@@ -987,7 +987,7 @@ mod tests {
 
     #[test]
     fn dispatch_set_callback_works() {
-        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
+        let dispatch = Dispatch::<TestState>::new(&Context::new());
         let old = dispatch.get();
 
         let cb = dispatch.set_callback(|_| TestState(1));
@@ -998,7 +998,7 @@ mod tests {
 
     #[test]
     fn dispatch_reduce_mut_works() {
-        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
+        let dispatch = Dispatch::<TestState>::new(&Context::new());
         let old = dispatch.get();
 
         dispatch.reduce_mut(|state| state.0 += 1);
@@ -1009,7 +1009,7 @@ mod tests {
     #[cfg(feature = "future")]
     #[async_std::test]
     async fn dispatch_reduce_mut_future_works() {
-        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
+        let dispatch = Dispatch::<TestState>::new(&Context::new());
         let old = dispatch.get();
 
         dispatch
@@ -1021,7 +1021,7 @@ mod tests {
 
     #[test]
     fn dispatch_reduce_works() {
-        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
+        let dispatch = Dispatch::<TestState>::new(&Context::new());
         let old = dispatch.get();
 
         dispatch.reduce(|_| TestState(1).into());
@@ -1032,7 +1032,7 @@ mod tests {
     #[cfg(feature = "future")]
     #[async_std::test]
     async fn dispatch_reduce_future_works() {
-        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
+        let dispatch = Dispatch::<TestState>::new(&Context::new());
         let old = dispatch.get();
 
         dispatch
@@ -1044,7 +1044,7 @@ mod tests {
 
     #[test]
     fn dispatch_reduce_callback_works() {
-        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
+        let dispatch = Dispatch::<TestState>::new(&Context::new());
         let old = dispatch.get();
 
         let cb = dispatch.reduce_callback(|_| TestState(1).into());
@@ -1056,7 +1056,7 @@ mod tests {
     #[cfg(feature = "future")]
     #[async_std::test]
     async fn dispatch_reduce_future_callback_compiles() {
-        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
+        let dispatch = Dispatch::<TestState>::new(&Context::new());
 
         let _ = dispatch.reduce_future_callback::<_, _, ()>(|state| async move {
             TestState(state.0 + 1).into()
@@ -1065,7 +1065,7 @@ mod tests {
 
     #[test]
     fn dispatch_reduce_mut_callback_works() {
-        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
+        let dispatch = Dispatch::<TestState>::new(&Context::new());
         let old = dispatch.get();
 
         let cb = dispatch.reduce_mut_callback(|state| state.0 += 1);
@@ -1077,7 +1077,7 @@ mod tests {
     #[cfg(feature = "future")]
     #[async_std::test]
     async fn dispatch_reduce_mut_future_callback_compiles() {
-        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
+        let dispatch = Dispatch::<TestState>::new(&Context::new());
 
         let _ = dispatch.reduce_mut_future_callback::<_, _, ()>(|state| {
             Box::pin(async move {
@@ -1089,7 +1089,7 @@ mod tests {
     #[cfg(feature = "future")]
     #[async_std::test]
     async fn dispatch_reduce_future_callback_with_compiles() {
-        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
+        let dispatch = Dispatch::<TestState>::new(&Context::new());
 
         let _ = dispatch.reduce_future_callback_with(|state, e: u32| async move {
             TestState(state.0 + e).into()
@@ -1098,7 +1098,7 @@ mod tests {
 
     #[test]
     fn dispatch_reduce_callback_with_works() {
-        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
+        let dispatch = Dispatch::<TestState>::new(&Context::new());
         let old = dispatch.get();
 
         let cb = dispatch.reduce_callback_with(|_, _| TestState(1).into());
@@ -1109,7 +1109,7 @@ mod tests {
 
     #[test]
     fn dispatch_reduce_mut_callback_with_works() {
-        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
+        let dispatch = Dispatch::<TestState>::new(&Context::new());
         let old = dispatch.get();
 
         let cb = dispatch.reduce_mut_callback_with(|state, val| state.0 += val);
@@ -1121,7 +1121,7 @@ mod tests {
     #[cfg(feature = "future")]
     #[async_std::test]
     async fn dispatch_reduce_mut_future_callback_with_compiles() {
-        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
+        let dispatch = Dispatch::<TestState>::new(&Context::new());
 
         let _ = dispatch.reduce_mut_future_callback_with::<_, _, u32>(|state, e| {
             Box::pin(async move {
@@ -1132,7 +1132,7 @@ mod tests {
 
     #[test]
     fn dispatch_apply_works() {
-        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
+        let dispatch = Dispatch::<TestState>::new(&Context::new());
         let old = dispatch.get();
 
         dispatch.apply(Msg);
@@ -1143,7 +1143,7 @@ mod tests {
     #[cfg(feature = "future")]
     #[async_std::test]
     async fn apply_future_changes_value() {
-        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
+        let dispatch = Dispatch::<TestState>::new(&Context::new());
         let old = dispatch.get();
 
         dispatch.apply_future(Msg).await;
@@ -1155,7 +1155,7 @@ mod tests {
 
     #[test]
     fn dispatch_apply_callback_works() {
-        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
+        let dispatch = Dispatch::<TestState>::new(&Context::new());
         let old = dispatch.get();
 
         let cb = dispatch.apply_callback(|_| Msg);
@@ -1167,7 +1167,7 @@ mod tests {
     #[cfg(feature = "future")]
     #[async_std::test]
     async fn apply_future_callback_compiles() {
-        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
+        let dispatch = Dispatch::<TestState>::new(&Context::new());
 
         dispatch.apply_future_callback(|_: ()| Msg);
     }
@@ -1179,13 +1179,13 @@ mod tests {
 
         let _id = {
             let flag = flag.clone();
-            Dispatch::<TestState>::with_cx(&cx)
+            Dispatch::<TestState>::new(&cx)
                 .subscribe(move |_| flag.clone().with_mut(|flag| *flag = true))
         };
 
         *flag.borrow_mut() = false;
 
-        Dispatch::<TestState>::with_cx(&cx).reduce_mut(|state| state.0 += 1);
+        Dispatch::<TestState>::new(&cx).reduce_mut(|state| state.0 += 1);
 
         assert!(*flag.borrow());
     }
@@ -1194,14 +1194,14 @@ mod tests {
     fn subscriber_is_not_notified_when_state_is_same() {
         let cx = Context::new();
         let flag = Mrc::new(false);
-        let dispatch = Dispatch::<TestState>::with_cx(&cx);
+        let dispatch = Dispatch::<TestState>::new(&cx);
 
         // TestState(1)
         dispatch.reduce_mut(|_| {});
 
         let _id = {
             let flag = flag.clone();
-            Dispatch::<TestState>::with_cx(&cx)
+            Dispatch::<TestState>::new(&cx)
                 .subscribe(move |_| flag.clone().with_mut(|flag| *flag = true))
         };
 
@@ -1220,7 +1220,7 @@ mod tests {
 
         assert!(entry.store.borrow().borrow().0.is_empty());
 
-        let dispatch = Dispatch::<TestState>::with_cx(&cx).subscribe(|_| ());
+        let dispatch = Dispatch::<TestState>::new(&cx).subscribe(|_| ());
 
         assert!(!entry.store.borrow().borrow().0.is_empty());
 
@@ -1236,7 +1236,7 @@ mod tests {
 
         assert!(entry.store.borrow().borrow().0.is_empty());
 
-        let dispatch = Dispatch::<TestState>::with_cx(&cx).subscribe(|_| ());
+        let dispatch = Dispatch::<TestState>::new(&cx).subscribe(|_| ());
         let dispatch_clone = dispatch.clone();
 
         assert!(!entry.store.borrow().borrow().0.is_empty());

--- a/crates/yewdux/src/dispatch.rs
+++ b/crates/yewdux/src/dispatch.rs
@@ -54,7 +54,7 @@ impl<S: Store> Dispatch<S> {
     /// Create a new dispatch with the global context (thread local).
     ///
     /// This is only available for wasm. For SSR, see the YewduxRoot pattern.
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(any(doc, feature = "doctests", target_arch = "wasm32"))]
     pub fn global() -> Self {
         Self::new(&Context::global())
     }
@@ -103,7 +103,7 @@ impl<S: Store> Dispatch<S> {
     ///
     ///     fn create(ctx: &Context<Self>) -> Self {
     ///         let on_change = ctx.link().callback(Msg::State);
-    ///         let dispatch = Dispatch::subscribe_global(on_change);
+    ///         let dispatch = Dispatch::global().subscribe(on_change);
     ///         Self {
     ///             state: dispatch.get(),
     ///             dispatch,
@@ -341,8 +341,9 @@ impl<S: Store> Dispatch<S> {
     /// # struct State {
     /// #     count: u32,
     /// # }
-    /// # fn main() {
-    /// let dispatch = Dispatch::<State>::global();
+    /// # #[hook]
+    /// # fn use_foo() {
+    /// let dispatch = use_dispatch::<State>();
     /// let onchange = dispatch.set_callback(|event: Event| {
     ///     let value = event.target_unchecked_into::<web_sys::HtmlInputElement>().value();
     ///     State { count: value.parse().unwrap() }
@@ -760,8 +761,9 @@ impl<S: Store> Dispatch<S> {
     /// # async fn get_incr() -> u32 {
     /// #     1
     /// # }
-    /// # fn main() {
-    /// let dispatch = Dispatch::<State>::global();
+    /// # #[hook]
+    /// # fn use_foo() {
+    /// let dispatch = use_dispatch::<State>();
     /// let onchange = dispatch.reduce_mut_future_callback_with(|state, event: Event| {
     ///     Box::pin(async move {
     ///         let value = event

--- a/crates/yewdux/src/dispatch.rs
+++ b/crates/yewdux/src/dispatch.rs
@@ -8,14 +8,12 @@
 //!     count: usize,
 //!  }
 //!
-//!  # fn main() {
-//!  let dispatch = Dispatch::<State>::new();
+//!  let dispatch = Dispatch::<State>::global();
 //!  dispatch.reduce_mut(|state| state.count = 1);
 //!
 //!  let state = dispatch.get();
 //!
 //!  assert!(state.count == 1);
-//!  # }
 //!  ```
 //!
 
@@ -82,7 +80,7 @@ impl<S: Store> Dispatch<S> {
     ///
     ///     fn create(ctx: &Context<Self>) -> Self {
     ///         let on_change = ctx.link().callback(Msg::State);
-    ///         let dispatch = Dispatch::subscribe(on_change);
+    ///         let dispatch = Dispatch::subscribe_global(on_change);
     ///         Self {
     ///             state: dispatch.get(),
     ///             dispatch,
@@ -160,7 +158,7 @@ impl<S: Store> Dispatch<S> {
     /// }
     ///
     /// # fn main() {
-    /// # let dispatch = Dispatch::<State>::new();
+    /// let dispatch = Dispatch::<State>::global();
     /// dispatch.apply(AddOne);
     /// # ;
     /// # }
@@ -197,7 +195,7 @@ impl<S: Store> Dispatch<S> {
     /// }
     ///
     /// # async fn do_thing() {
-    /// # let dispatch = Dispatch::<State>::new();
+    /// let dispatch = Dispatch::<State>::global();
     /// dispatch.apply_future(AddOne).await;
     /// # ;
     /// # }
@@ -229,7 +227,7 @@ impl<S: Store> Dispatch<S> {
     /// }
     ///
     /// # fn main() {
-    /// # let dispatch = Dispatch::<State>::new();
+    /// let dispatch = Dispatch::<State>::global();
     /// let onclick = dispatch.apply_callback(|_| AddOne);
     /// html! {
     ///     <button {onclick}>{"+1"}</button>
@@ -277,7 +275,7 @@ impl<S: Store> Dispatch<S> {
     /// }
     ///
     /// # fn main() {
-    /// # let dispatch = Dispatch::<State>::new();
+    /// let dispatch = Dispatch::<State>::global();
     /// let onclick = dispatch.apply_future_callback(|_| AddOne);
     /// html! {
     ///     <button {onclick}>{"+1"}</button>
@@ -311,7 +309,7 @@ impl<S: Store> Dispatch<S> {
     /// #     count: u32,
     /// # }
     /// # fn main() {
-    /// # let dispatch = Dispatch::<State>::new();
+    /// let dispatch = Dispatch::<State>::global();
     /// dispatch.set(State { count: 0 });
     /// # }
     /// ```
@@ -329,7 +327,7 @@ impl<S: Store> Dispatch<S> {
     /// #     count: u32,
     /// # }
     /// # fn main() {
-    /// # let dispatch = Dispatch::<State>::new();
+    /// let dispatch = Dispatch::<State>::global();
     /// let onchange = dispatch.set_callback(|event: Event| {
     ///     let value = event.target_unchecked_into::<web_sys::HtmlInputElement>().value();
     ///     State { count: value.parse().unwrap() }
@@ -361,7 +359,7 @@ impl<S: Store> Dispatch<S> {
     /// #     count: u32,
     /// # }
     /// # fn main() {
-    /// # let dispatch = Dispatch::<State>::new();
+    /// let dispatch = Dispatch::<State>::global();
     /// dispatch.reduce(|state| State { count: state.count + 1 }.into());
     /// # }
     /// ```
@@ -385,7 +383,7 @@ impl<S: Store> Dispatch<S> {
     /// #   1
     /// # }
     /// # async fn do_thing() {
-    /// # let dispatch = Dispatch::<State>::new();
+    /// let dispatch = Dispatch::<State>::global();
     /// dispatch
     ///     .reduce_future(|state| async move {
     ///         let incr = get_incr().await;
@@ -417,7 +415,7 @@ impl<S: Store> Dispatch<S> {
     /// #     count: u32,
     /// # }
     /// # fn main() {
-    /// # let dispatch = Dispatch::<State>::new();
+    /// let dispatch = Dispatch::<State>::global();
     /// let onclick = dispatch.reduce_callback(|state| State { count: state.count + 1 }.into());
     /// html! {
     ///     <button {onclick}>{"+1"}</button>
@@ -449,7 +447,7 @@ impl<S: Store> Dispatch<S> {
     /// #   1
     /// # }
     /// # fn main() {
-    /// # let dispatch = Dispatch::<State>::new();
+    /// let dispatch = Dispatch::<State>::global();
     /// let onclick = dispatch.reduce_future_callback(|state| async move {
     ///     let incr = get_incr().await;
     ///     State {
@@ -491,7 +489,7 @@ impl<S: Store> Dispatch<S> {
     /// #     count: u32,
     /// # }
     /// # fn main() {
-    /// # let dispatch = Dispatch::<State>::new();
+    /// let dispatch = Dispatch::<State>::global();
     /// let onchange = dispatch.reduce_callback_with(|state, event: Event| {
     ///     let value = event.target_unchecked_into::<web_sys::HtmlInputElement>().value();
     ///     State {
@@ -529,7 +527,7 @@ impl<S: Store> Dispatch<S> {
     /// #     1
     /// # }
     /// # fn main() {
-    /// # let dispatch = Dispatch::<State>::new();
+    /// let dispatch = Dispatch::<State>::global();
     /// let onchange = dispatch.reduce_future_callback_with(|state, event: Event| async move {
     ///     let value = event.target_unchecked_into::<web_sys::HtmlInputElement>().value();
     ///     let incr = get_incr().await;
@@ -573,7 +571,7 @@ impl<S: Store> Dispatch<S> {
     /// #     count: u32,
     /// # }
     /// # fn main() {
-    /// # let dispatch = Dispatch::<State>::new();
+    /// let dispatch = Dispatch::<State>::global();
     /// dispatch.reduce_mut(|state| state.count += 1);
     /// # }
     /// ```
@@ -600,7 +598,7 @@ impl<S: Store> Dispatch<S> {
     /// #   1
     /// # }
     /// # async fn do_thing() {
-    /// # let dispatch = Dispatch::<State>::new();
+    /// let dispatch = Dispatch::<State>::global();
     /// dispatch
     ///     .reduce_mut_future(|state| {
     ///         Box::pin(async move {
@@ -630,7 +628,7 @@ impl<S: Store> Dispatch<S> {
     /// #     count: u32,
     /// # }
     /// # fn main() {
-    /// # let dispatch = Dispatch::<State>::new();
+    /// let dispatch = Dispatch::<State>::global();
     /// let onclick = dispatch.reduce_mut_callback(|s| s.count += 1);
     /// html! {
     ///     <button {onclick}>{"+1"}</button>
@@ -665,7 +663,7 @@ impl<S: Store> Dispatch<S> {
     /// #   1
     /// # }
     /// # fn main() {
-    /// # let dispatch = Dispatch::<State>::new();
+    /// let dispatch = Dispatch::<State>::global();
     /// let onclick = dispatch.reduce_mut_future_callback(|state| Box::pin(async move {
     ///     let incr = get_incr().await;
     ///     state.count += incr;
@@ -705,7 +703,7 @@ impl<S: Store> Dispatch<S> {
     /// #     count: u32,
     /// # }
     /// # fn main() {
-    /// # let dispatch = Dispatch::<State>::new();
+    /// let dispatch = Dispatch::<State>::global();
     /// let onchange = dispatch.reduce_mut_callback_with(|state, event: Event| {
     ///     let value = event.target_unchecked_into::<web_sys::HtmlInputElement>().value();
     ///     state.count = value.parse().unwrap();
@@ -744,7 +742,7 @@ impl<S: Store> Dispatch<S> {
     /// #     1
     /// # }
     /// # fn main() {
-    /// # let dispatch = Dispatch::<State>::new();
+    /// let dispatch = Dispatch::<State>::global();
     /// let onchange = dispatch.reduce_mut_future_callback_with(|state, event: Event| {
     ///     Box::pin(async move {
     ///         let value = event

--- a/crates/yewdux/src/dispatch.rs
+++ b/crates/yewdux/src/dispatch.rs
@@ -53,7 +53,7 @@ impl<S: Store> Default for Dispatch<S> {
 impl<S: Store> Dispatch<S> {
     /// Create a new dispatch with the global context (thread local).
     ///
-    /// This is only available for wasm32 targets. For SSR, see the YewduxRoot pattern.
+    /// This is only available for wasm. For SSR, see the YewduxRoot pattern.
     #[cfg(target_arch = "wasm32")]
     pub fn global() -> Self {
         Self::new(&Context::global())
@@ -68,7 +68,7 @@ impl<S: Store> Dispatch<S> {
     }
 
     /// Get the context used by this dispatch.
-    pub fn cx(&self) -> &Context {
+    pub fn context(&self) -> &Context {
         &self.cx
     }
 

--- a/crates/yewdux/src/dispatch.rs
+++ b/crates/yewdux/src/dispatch.rs
@@ -805,7 +805,7 @@ mod tests {
     #[derive(Clone, PartialEq, Eq)]
     struct TestState(u32);
     impl Store for TestState {
-        fn new() -> Self {
+        fn new(_cx: &Context) -> Self {
             Self(0)
         }
 
@@ -816,7 +816,7 @@ mod tests {
     #[derive(PartialEq, Eq)]
     struct TestStateNoClone(u32);
     impl Store for TestStateNoClone {
-        fn new() -> Self {
+        fn new(_cx: &Context) -> Self {
             Self(0)
         }
 

--- a/crates/yewdux/src/dispatch.rs
+++ b/crates/yewdux/src/dispatch.rs
@@ -37,12 +37,12 @@ pub struct Dispatch<S: Store> {
 
 impl<S: Store> Dispatch<S> {
     /// Create a new dispatch with the global context (thread local).
-    pub fn global() -> Self {
-        Self::new(&Context::global())
+    pub fn new() -> Self {
+        Self::with_cx(&Context::global())
     }
 
     /// Create a new dispatch using the given context.
-    pub fn new(cx: &Context) -> Self {
+    pub fn with_cx(cx: &Context) -> Self {
         Self {
             _subscriber_id: Default::default(),
             context: cx.clone(),
@@ -845,12 +845,12 @@ mod tests {
 
     #[test]
     fn apply_no_clone() {
-        Dispatch::new(&Context::new()).reduce(|_| TestStateNoClone(1).into());
+        Dispatch::with_cx(&Context::new()).reduce(|_| TestStateNoClone(1).into());
     }
 
     #[test]
     fn reduce_changes_value() {
-        let dispatch = Dispatch::<TestState>::new(&Context::new());
+        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
 
         let old = dispatch.get();
 
@@ -865,7 +865,7 @@ mod tests {
     #[async_std::test]
     async fn reduce_future_changes_value() {
         let cx = Context::new();
-        let dispatch = Dispatch::<TestState>::new(&cx);
+        let dispatch = Dispatch::<TestState>::with_cx(&cx);
         let old = dispatch.get();
 
         dispatch
@@ -883,7 +883,7 @@ mod tests {
         use std::time::Duration;
 
         let cx = Context::new();
-        let dispatch = Dispatch::<TestState>::new(&cx);
+        let dispatch = Dispatch::<TestState>::with_cx(&cx);
 
         dispatch
             .reduce_future(|state| async move {
@@ -897,7 +897,7 @@ mod tests {
 
     #[test]
     fn reduce_mut_changes_value() {
-        let dispatch = Dispatch::<TestState>::new(&Context::new());
+        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
         let old = dispatch.get();
 
         dispatch.reduce_mut(|state| *state = TestState(1));
@@ -910,7 +910,7 @@ mod tests {
     #[cfg(feature = "future")]
     #[async_std::test]
     async fn reduce_mut_future_changes_value() {
-        let dispatch = Dispatch::<TestState>::new(&Context::new());
+        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
         let old = dispatch.get();
 
         dispatch
@@ -925,19 +925,19 @@ mod tests {
     #[test]
     fn reduce_does_not_require_static() {
         let val = "1".to_string();
-        Dispatch::new(&Context::new()).reduce(|_| TestState(val.parse().unwrap()).into());
+        Dispatch::with_cx(&Context::new()).reduce(|_| TestState(val.parse().unwrap()).into());
     }
 
     #[test]
     fn reduce_mut_does_not_require_static() {
         let val = "1".to_string();
-        Dispatch::new(&Context::new())
+        Dispatch::with_cx(&Context::new())
             .reduce_mut(|state: &mut TestState| state.0 = val.parse().unwrap());
     }
 
     #[test]
     fn set_changes_value() {
-        let dispatch = Dispatch::<TestState>::new(&Context::new());
+        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
 
         let old = dispatch.get();
 
@@ -950,7 +950,7 @@ mod tests {
 
     #[test]
     fn apply_changes_value() {
-        let dispatch = Dispatch::<TestState>::new(&Context::new());
+        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
         let old = dispatch.get();
 
         dispatch.apply(Msg);
@@ -962,7 +962,7 @@ mod tests {
 
     #[test]
     fn dispatch_set_works() {
-        let dispatch = Dispatch::<TestState>::new(&Context::new());
+        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
         let old = dispatch.get();
 
         dispatch.set(TestState(1));
@@ -972,7 +972,7 @@ mod tests {
 
     #[test]
     fn dispatch_set_callback_works() {
-        let dispatch = Dispatch::<TestState>::new(&Context::new());
+        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
         let old = dispatch.get();
 
         let cb = dispatch.set_callback(|_| TestState(1));
@@ -983,7 +983,7 @@ mod tests {
 
     #[test]
     fn dispatch_reduce_mut_works() {
-        let dispatch = Dispatch::<TestState>::new(&Context::new());
+        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
         let old = dispatch.get();
 
         dispatch.reduce_mut(|state| state.0 += 1);
@@ -994,7 +994,7 @@ mod tests {
     #[cfg(feature = "future")]
     #[async_std::test]
     async fn dispatch_reduce_mut_future_works() {
-        let dispatch = Dispatch::<TestState>::new(&Context::new());
+        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
         let old = dispatch.get();
 
         dispatch
@@ -1006,7 +1006,7 @@ mod tests {
 
     #[test]
     fn dispatch_reduce_works() {
-        let dispatch = Dispatch::<TestState>::new(&Context::new());
+        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
         let old = dispatch.get();
 
         dispatch.reduce(|_| TestState(1).into());
@@ -1017,7 +1017,7 @@ mod tests {
     #[cfg(feature = "future")]
     #[async_std::test]
     async fn dispatch_reduce_future_works() {
-        let dispatch = Dispatch::<TestState>::new(&Context::new());
+        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
         let old = dispatch.get();
 
         dispatch
@@ -1029,7 +1029,7 @@ mod tests {
 
     #[test]
     fn dispatch_reduce_callback_works() {
-        let dispatch = Dispatch::<TestState>::new(&Context::new());
+        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
         let old = dispatch.get();
 
         let cb = dispatch.reduce_callback(|_| TestState(1).into());
@@ -1041,7 +1041,7 @@ mod tests {
     #[cfg(feature = "future")]
     #[async_std::test]
     async fn dispatch_reduce_future_callback_compiles() {
-        let dispatch = Dispatch::<TestState>::new(&Context::new());
+        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
 
         let _ = dispatch.reduce_future_callback::<_, _, ()>(|state| async move {
             TestState(state.0 + 1).into()
@@ -1050,7 +1050,7 @@ mod tests {
 
     #[test]
     fn dispatch_reduce_mut_callback_works() {
-        let dispatch = Dispatch::<TestState>::new(&Context::new());
+        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
         let old = dispatch.get();
 
         let cb = dispatch.reduce_mut_callback(|state| state.0 += 1);
@@ -1062,7 +1062,7 @@ mod tests {
     #[cfg(feature = "future")]
     #[async_std::test]
     async fn dispatch_reduce_mut_future_callback_compiles() {
-        let dispatch = Dispatch::<TestState>::new(&Context::new());
+        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
 
         let _ = dispatch.reduce_mut_future_callback::<_, _, ()>(|state| {
             Box::pin(async move {
@@ -1074,7 +1074,7 @@ mod tests {
     #[cfg(feature = "future")]
     #[async_std::test]
     async fn dispatch_reduce_future_callback_with_compiles() {
-        let dispatch = Dispatch::<TestState>::new(&Context::new());
+        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
 
         let _ = dispatch.reduce_future_callback_with(|state, e: u32| async move {
             TestState(state.0 + e).into()
@@ -1083,7 +1083,7 @@ mod tests {
 
     #[test]
     fn dispatch_reduce_callback_with_works() {
-        let dispatch = Dispatch::<TestState>::new(&Context::new());
+        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
         let old = dispatch.get();
 
         let cb = dispatch.reduce_callback_with(|_, _| TestState(1).into());
@@ -1094,7 +1094,7 @@ mod tests {
 
     #[test]
     fn dispatch_reduce_mut_callback_with_works() {
-        let dispatch = Dispatch::<TestState>::new(&Context::new());
+        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
         let old = dispatch.get();
 
         let cb = dispatch.reduce_mut_callback_with(|state, val| state.0 += val);
@@ -1106,7 +1106,7 @@ mod tests {
     #[cfg(feature = "future")]
     #[async_std::test]
     async fn dispatch_reduce_mut_future_callback_with_compiles() {
-        let dispatch = Dispatch::<TestState>::new(&Context::new());
+        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
 
         let _ = dispatch.reduce_mut_future_callback_with::<_, _, u32>(|state, e| {
             Box::pin(async move {
@@ -1117,7 +1117,7 @@ mod tests {
 
     #[test]
     fn dispatch_apply_works() {
-        let dispatch = Dispatch::<TestState>::new(&Context::new());
+        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
         let old = dispatch.get();
 
         dispatch.apply(Msg);
@@ -1128,7 +1128,7 @@ mod tests {
     #[cfg(feature = "future")]
     #[async_std::test]
     async fn apply_future_changes_value() {
-        let dispatch = Dispatch::<TestState>::new(&Context::new());
+        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
         let old = dispatch.get();
 
         dispatch.apply_future(Msg).await;
@@ -1140,7 +1140,7 @@ mod tests {
 
     #[test]
     fn dispatch_apply_callback_works() {
-        let dispatch = Dispatch::<TestState>::new(&Context::new());
+        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
         let old = dispatch.get();
 
         let cb = dispatch.apply_callback(|_| Msg);
@@ -1152,7 +1152,7 @@ mod tests {
     #[cfg(feature = "future")]
     #[async_std::test]
     async fn apply_future_callback_compiles() {
-        let dispatch = Dispatch::<TestState>::new(&Context::new());
+        let dispatch = Dispatch::<TestState>::with_cx(&Context::new());
 
         dispatch.apply_future_callback(|_: ()| Msg);
     }
@@ -1172,7 +1172,7 @@ mod tests {
 
         *flag.borrow_mut() = false;
 
-        Dispatch::<TestState>::new(&cx).reduce_mut(|state| state.0 += 1);
+        Dispatch::<TestState>::with_cx(&cx).reduce_mut(|state| state.0 += 1);
 
         assert!(*flag.borrow());
     }
@@ -1181,7 +1181,7 @@ mod tests {
     fn subscriber_is_not_notified_when_state_is_same() {
         let cx = Context::new();
         let flag = Mrc::new(false);
-        let dispatch = Dispatch::<TestState>::new(&cx);
+        let dispatch = Dispatch::<TestState>::with_cx(&cx);
 
         // TestState(1)
         dispatch.reduce_mut(|_| {});

--- a/crates/yewdux/src/functional.rs
+++ b/crates/yewdux/src/functional.rs
@@ -34,12 +34,10 @@ use crate::{dispatch::Dispatch, store::Store};
 pub fn use_store<S: Store>() -> (Rc<S>, Dispatch<S>) {
     let ctx =
         use_context::<crate::context::Context>().unwrap_or_else(crate::context::Context::global);
-    let state: UseStateHandle<Rc<S>> = use_state(|| Dispatch::with_context(&ctx).get());
+    let state: UseStateHandle<Rc<S>> = use_state(|| Dispatch::new(&ctx).get());
     let dispatch = {
         let state = state.clone();
-        use_state(move || {
-            Dispatch::<S>::subscribe_silent_with_context(move |val| state.set(val), &ctx)
-        })
+        use_state(move || Dispatch::<S>::subscribe_silent(move |val| state.set(val), &ctx))
     };
 
     (Rc::clone(&state), dispatch.deref().clone())
@@ -162,7 +160,7 @@ where
         use_context::<crate::context::Context>().unwrap_or_else(crate::context::Context::global);
     // Given to user, this is what we update to force a re-render.
     let selected = {
-        let state = Dispatch::with_context(&ctx).get();
+        let state = Dispatch::new(&ctx).get();
         let value = selector(&state, &deps);
 
         use_state(|| Rc::new(value))
@@ -178,7 +176,7 @@ where
         use_memo(
             move |deps| {
                 let deps = deps.clone();
-                Dispatch::subscribe_with_context(
+                Dispatch::subscribe(
                     move |val: Rc<S>| {
                         let value = selector(&val, &deps);
 

--- a/crates/yewdux/src/functional.rs
+++ b/crates/yewdux/src/functional.rs
@@ -17,6 +17,12 @@ fn use_cx() -> Context {
     }
 }
 
+#[hook]
+pub fn use_dispatch<S: Store>() -> Dispatch<S> {
+    let cx = use_cx();
+    Dispatch::new(&cx)
+}
+
 /// This hook allows accessing the state of a store. When the store is modified, a re-render is
 /// automatically triggered.
 ///
@@ -78,8 +84,9 @@ pub fn use_store_value<S: Store>() -> Rc<S> {
 ///
 /// #[function_component]
 /// fn App() -> Html {
+///     let dispatch = use_dispatch::<State>();
 ///     let count = use_selector(|state: &State| state.count);
-///     let onclick = Dispatch::<State>::new().reduce_mut_callback(|state| state.count += 1);
+///     let onclick = dispatch.reduce_mut_callback(|state| state.count += 1);
 ///
 ///     html! {
 ///         <>

--- a/crates/yewdux/src/functional.rs
+++ b/crates/yewdux/src/functional.rs
@@ -3,10 +3,7 @@ use std::{ops::Deref, rc::Rc};
 
 use yew::functional::*;
 
-use crate::{
-    dispatch::{self, Dispatch},
-    store::Store,
-};
+use crate::{dispatch::Dispatch, store::Store};
 
 /// This hook allows accessing the state of a store. When the store is modified, a re-render is
 /// automatically triggered.
@@ -35,7 +32,7 @@ use crate::{
 /// ```
 #[hook]
 pub fn use_store<S: Store>() -> (Rc<S>, Dispatch<S>) {
-    let state = use_state(|| dispatch::get::<S>());
+    let state = use_state(|| Dispatch::<S>::new().get());
 
     let dispatch = {
         let state = state.clone();
@@ -160,7 +157,7 @@ where
 {
     // Given to user, this is what we update to force a re-render.
     let selected = {
-        let state = dispatch::get::<S>();
+        let state = Dispatch::new().get();
         let value = selector(&state, &deps);
 
         use_state(|| Rc::new(value))

--- a/crates/yewdux/src/functional.rs
+++ b/crates/yewdux/src/functional.rs
@@ -34,7 +34,7 @@ use crate::{dispatch::Dispatch, store::Store};
 pub fn use_store<S: Store>() -> (Rc<S>, Dispatch<S>) {
     let ctx =
         use_context::<crate::context::Context>().unwrap_or_else(crate::context::Context::global);
-    let state: UseStateHandle<Rc<S>> = use_state(|| Dispatch::new(&ctx).get());
+    let state: UseStateHandle<Rc<S>> = use_state(|| Dispatch::with_cx(&ctx).get());
     let dispatch = {
         let state = state.clone();
         use_state(move || Dispatch::<S>::subscribe_silent(move |val| state.set(val), &ctx))
@@ -160,7 +160,7 @@ where
         use_context::<crate::context::Context>().unwrap_or_else(crate::context::Context::global);
     // Given to user, this is what we update to force a re-render.
     let selected = {
-        let state = Dispatch::new(&ctx).get();
+        let state = Dispatch::with_cx(&ctx).get();
         let value = selector(&state, &deps);
 
         use_state(|| Rc::new(value))

--- a/crates/yewdux/src/functional.rs
+++ b/crates/yewdux/src/functional.rs
@@ -67,7 +67,7 @@ pub fn use_store_value<S: Store>() -> Rc<S> {
 /// #[function_component]
 /// fn App() -> Html {
 ///     let count = use_selector(|state: &State| state.count);
-///     let onclick = Dispatch::<State>::new().reduce_mut_callback(|state| state.count += 1);
+///     let onclick = Dispatch::<State>::global().reduce_mut_callback(|state| state.count += 1);
 ///
 ///     html! {
 ///         <>

--- a/crates/yewdux/src/lib.rs
+++ b/crates/yewdux/src/lib.rs
@@ -30,7 +30,7 @@
 //! ```
 #![allow(clippy::needless_doctest_main)]
 
-mod context;
+pub mod context;
 pub mod dispatch;
 pub mod functional;
 pub mod listener;

--- a/crates/yewdux/src/lib.rs
+++ b/crates/yewdux/src/lib.rs
@@ -60,8 +60,8 @@ pub mod prelude {
         context_provider::YewduxRoot,
         dispatch::Dispatch,
         functional::{
-            use_selector, use_selector_eq, use_selector_eq_with_deps, use_selector_with_deps,
-            use_store, use_store_value,
+            use_dispatch, use_selector, use_selector_eq, use_selector_eq_with_deps,
+            use_selector_with_deps, use_store, use_store_value,
         },
         listener::{init_listener, Listener},
         store::{Reducer, Store},

--- a/crates/yewdux/src/lib.rs
+++ b/crates/yewdux/src/lib.rs
@@ -31,6 +31,7 @@
 #![allow(clippy::needless_doctest_main)]
 
 pub mod context;
+pub mod context_provider;
 pub mod dispatch;
 pub mod functional;
 pub mod listener;
@@ -52,6 +53,7 @@ pub mod prelude {
     //! Default exports
 
     pub use crate::{
+        context_provider::YewduxRoot,
         dispatch::Dispatch,
         functional::{
             use_selector, use_selector_eq, use_selector_eq_with_deps, use_selector_with_deps,

--- a/crates/yewdux/src/lib.rs
+++ b/crates/yewdux/src/lib.rs
@@ -49,6 +49,10 @@ pub use log;
 #[doc(hidden)]
 pub use async_trait::async_trait;
 
+// Allow shorthand, like `yewdux::Dispatch`
+pub use context::Context;
+pub use prelude::*;
+
 pub mod prelude {
     //! Default exports
 

--- a/crates/yewdux/src/listener.rs
+++ b/crates/yewdux/src/listener.rs
@@ -26,9 +26,8 @@ pub fn init_listener<L: Listener>(listener: L, cx: &Context) {
     let dispatch = {
         let listener = Mrc::new(listener);
         let cxo = cx.clone();
-        Dispatch::subscribe_silent(
+        Dispatch::with_cx(cx).subscribe_silent(
             move |state| listener.borrow_mut().on_change(&cxo, state),
-            cx,
         )
     };
 

--- a/crates/yewdux/src/listener.rs
+++ b/crates/yewdux/src/listener.rs
@@ -26,9 +26,8 @@ pub fn init_listener<L: Listener>(listener: L, cx: &Context) {
     let dispatch = {
         let listener = Mrc::new(listener);
         let cxo = cx.clone();
-        Dispatch::with_cx(cx).subscribe_silent(
-            move |state| listener.borrow_mut().on_change(&cxo, state),
-        )
+        Dispatch::with_cx(cx)
+            .subscribe_silent(move |state| listener.borrow_mut().on_change(&cxo, state))
     };
 
     cx.reduce_mut(|state: &mut Mrc<ListenerStore<L>>| state.borrow_mut().0 = Some(dispatch));
@@ -128,7 +127,7 @@ mod tests {
 
     #[test]
     fn listener_of_different_type_is_not_replaced() {
-        let cx = Context::global();
+        let cx = Context::new();
         let listener1 = TestListener(Default::default());
         let listener2 = AnotherTestListener(Default::default());
 
@@ -148,6 +147,7 @@ mod tests {
 
     #[test]
     fn can_init_listener_from_store() {
-        Context::global().get::<TestState2>();
+        let cx = Context::new();
+        cx.get::<TestState2>();
     }
 }

--- a/crates/yewdux/src/listener.rs
+++ b/crates/yewdux/src/listener.rs
@@ -26,7 +26,7 @@ pub fn init_listener<L: Listener>(listener: L, cx: &Context) {
     let dispatch = {
         let listener = Mrc::new(listener);
         let cxo = cx.clone();
-        Dispatch::with_cx(cx)
+        Dispatch::new(cx)
             .subscribe_silent(move |state| listener.borrow_mut().on_change(&cxo, state))
     };
 
@@ -100,7 +100,7 @@ mod tests {
 
         init_listener(listener.clone(), &cx);
 
-        Dispatch::with_cx(&cx).reduce_mut(|state: &mut TestState| state.0 = 1);
+        Dispatch::new(&cx).reduce_mut(|state: &mut TestState| state.0 = 1);
 
         assert_eq!(listener.0.get(), 1)
     }
@@ -113,13 +113,13 @@ mod tests {
 
         init_listener(listener1.clone(), &cx);
 
-        Dispatch::with_cx(&cx).reduce_mut(|state: &mut TestState| state.0 = 1);
+        Dispatch::new(&cx).reduce_mut(|state: &mut TestState| state.0 = 1);
 
         assert_eq!(listener1.0.get(), 1);
 
         init_listener(listener2.clone(), &cx);
 
-        Dispatch::with_cx(&cx).reduce_mut(|state: &mut TestState| state.0 = 2);
+        Dispatch::new(&cx).reduce_mut(|state: &mut TestState| state.0 = 2);
 
         assert_eq!(listener1.0.get(), 1);
         assert_eq!(listener2.0.get(), 2);

--- a/crates/yewdux/src/listener.rs
+++ b/crates/yewdux/src/listener.rs
@@ -102,7 +102,7 @@ mod tests {
 
         init_listener(listener.clone(), &cx);
 
-        Dispatch::new(&cx).reduce_mut(|state: &mut TestState| state.0 = 1);
+        Dispatch::with_cx(&cx).reduce_mut(|state: &mut TestState| state.0 = 1);
 
         assert_eq!(listener.0.get(), 1)
     }
@@ -115,13 +115,13 @@ mod tests {
 
         init_listener(listener1.clone(), &cx);
 
-        Dispatch::new(&cx).reduce_mut(|state: &mut TestState| state.0 = 1);
+        Dispatch::with_cx(&cx).reduce_mut(|state: &mut TestState| state.0 = 1);
 
         assert_eq!(listener1.0.get(), 1);
 
         init_listener(listener2.clone(), &cx);
 
-        Dispatch::new(&cx).reduce_mut(|state: &mut TestState| state.0 = 2);
+        Dispatch::with_cx(&cx).reduce_mut(|state: &mut TestState| state.0 = 2);
 
         assert_eq!(listener1.0.get(), 1);
         assert_eq!(listener2.0.get(), 2);

--- a/crates/yewdux/src/mrc.rs
+++ b/crates/yewdux/src/mrc.rs
@@ -156,10 +156,8 @@ mod tests {
 
         let dispatch = {
             let flag = flag.clone();
-            Dispatch::<TestState>::subscribe(
-                move |_| flag.clone().with_mut(|flag| *flag = true),
-                &cx,
-            )
+            Dispatch::<TestState>::with_cx(&cx)
+                .subscribe(move |_| flag.clone().with_mut(|flag| *flag = true))
         };
 
         *flag.borrow_mut() = false;
@@ -178,10 +176,8 @@ mod tests {
 
         let dispatch = {
             let flag = flag.clone();
-            Dispatch::<TestState>::subscribe(
-                move |_| flag.clone().with_mut(|flag| *flag = true),
-                &cx,
-            )
+            Dispatch::<TestState>::with_cx(&cx)
+                .subscribe(move |_| flag.clone().with_mut(|flag| *flag = true))
         };
 
         *flag.borrow_mut() = false;
@@ -193,7 +189,8 @@ mod tests {
 
     #[test]
     fn can_wrap_store_with_mrc() {
-        let dispatch = Dispatch::<Mrc<TestState>>::new();
+        let cx = Context::new();
+        let dispatch = Dispatch::<Mrc<TestState>>::with_cx(&cx);
         assert!(*dispatch.get().borrow().0.borrow() == 0)
     }
 }

--- a/crates/yewdux/src/mrc.rs
+++ b/crates/yewdux/src/mrc.rs
@@ -193,7 +193,7 @@ mod tests {
 
     #[test]
     fn can_wrap_store_with_mrc() {
-        let dispatch = Dispatch::<Mrc<TestState>>::global();
+        let dispatch = Dispatch::<Mrc<TestState>>::new();
         assert!(*dispatch.get().borrow().0.borrow() == 0)
     }
 }

--- a/crates/yewdux/src/mrc.rs
+++ b/crates/yewdux/src/mrc.rs
@@ -156,7 +156,7 @@ mod tests {
 
         let dispatch = {
             let flag = flag.clone();
-            Dispatch::<TestState>::with_cx(&cx)
+            Dispatch::<TestState>::new(&cx)
                 .subscribe(move |_| flag.clone().with_mut(|flag| *flag = true))
         };
 
@@ -176,7 +176,7 @@ mod tests {
 
         let dispatch = {
             let flag = flag.clone();
-            Dispatch::<TestState>::with_cx(&cx)
+            Dispatch::<TestState>::new(&cx)
                 .subscribe(move |_| flag.clone().with_mut(|flag| *flag = true))
         };
 
@@ -190,7 +190,7 @@ mod tests {
     #[test]
     fn can_wrap_store_with_mrc() {
         let cx = Context::new();
-        let dispatch = Dispatch::<Mrc<TestState>>::with_cx(&cx);
+        let dispatch = Dispatch::<Mrc<TestState>>::new(&cx);
         assert!(*dispatch.get().borrow().0.borrow() == 0)
     }
 }

--- a/crates/yewdux/src/mrc.rs
+++ b/crates/yewdux/src/mrc.rs
@@ -30,7 +30,7 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use crate::store::Store;
+use crate::{store::Store, Context};
 
 fn nonce() -> u32 {
     thread_local! {
@@ -83,8 +83,8 @@ impl<T> Mrc<T> {
 }
 
 impl<T: Store> Store for Mrc<T> {
-    fn new() -> Self {
-        T::new().into()
+    fn new(cx: &Context) -> Self {
+        T::new(cx).into()
     }
 
     fn should_notify(&self, other: &Self) -> bool {
@@ -129,7 +129,7 @@ mod tests {
     #[derive(Clone, PartialEq)]
     struct TestState(Mrc<u32>);
     impl Store for TestState {
-        fn new() -> Self {
+        fn new(_cx: &Context) -> Self {
             Self(Mrc::new(0))
         }
 
@@ -140,7 +140,7 @@ mod tests {
 
     struct CanImplStoreForMrcDirectly;
     impl Store for Mrc<CanImplStoreForMrcDirectly> {
-        fn new() -> Self {
+        fn new(_cx: &Context) -> Self {
             CanImplStoreForMrcDirectly.into()
         }
 

--- a/crates/yewdux/src/mrc.rs
+++ b/crates/yewdux/src/mrc.rs
@@ -122,7 +122,7 @@ impl<T> PartialEq for Mrc<T> {
 #[cfg(test)]
 mod tests {
 
-    use crate::{dispatch::Dispatch, store::Store};
+    use crate::{dispatch::Dispatch, store::Store, Context};
 
     use super::*;
 
@@ -152,10 +152,14 @@ mod tests {
     #[test]
     fn subscriber_is_notified_on_borrow_mut() {
         let flag = Mrc::new(false);
+        let cx = Context::new();
 
         let dispatch = {
             let flag = flag.clone();
-            Dispatch::<TestState>::subscribe(move |_| flag.clone().with_mut(|flag| *flag = true))
+            Dispatch::<TestState>::subscribe(
+                move |_| flag.clone().with_mut(|flag| *flag = true),
+                &cx,
+            )
         };
 
         *flag.borrow_mut() = false;
@@ -170,10 +174,14 @@ mod tests {
     #[test]
     fn subscriber_is_notified_on_with_mut() {
         let flag = Mrc::new(false);
+        let cx = Context::new();
 
         let dispatch = {
             let flag = flag.clone();
-            Dispatch::<TestState>::subscribe(move |_| flag.clone().with_mut(|flag| *flag = true))
+            Dispatch::<TestState>::subscribe(
+                move |_| flag.clone().with_mut(|flag| *flag = true),
+                &cx,
+            )
         };
 
         *flag.borrow_mut() = false;
@@ -185,7 +193,7 @@ mod tests {
 
     #[test]
     fn can_wrap_store_with_mrc() {
-        let dispatch = Dispatch::<Mrc<TestState>>::new();
+        let dispatch = Dispatch::<Mrc<TestState>>::global();
         assert!(*dispatch.get().borrow().0.borrow() == 0)
     }
 }

--- a/crates/yewdux/src/storage.rs
+++ b/crates/yewdux/src/storage.rs
@@ -144,7 +144,7 @@ pub fn init_tab_sync<S: Store + DeserializeOwned>(
     let cx = cx.clone();
     let closure = Closure::wrap(Box::new(move |_: &Event| match load(area) {
         Ok(Some(state)) => {
-            Dispatch::<S>::new(&cx).set(state);
+            Dispatch::<S>::with_cx(&cx).set(state);
         }
         Err(e) => {
             crate::log::error!("Unable to load state: {:?}", e);

--- a/crates/yewdux/src/storage.rs
+++ b/crates/yewdux/src/storage.rs
@@ -144,7 +144,7 @@ pub fn init_tab_sync<S: Store + DeserializeOwned>(
     let cx = cx.clone();
     let closure = Closure::wrap(Box::new(move |_: &Event| match load(area) {
         Ok(Some(state)) => {
-            Dispatch::<S>::with_cx(&cx).set(state);
+            Dispatch::<S>::new(&cx).set(state);
         }
         Err(e) => {
             crate::log::error!("Unable to load state: {:?}", e);

--- a/crates/yewdux/src/storage.rs
+++ b/crates/yewdux/src/storage.rs
@@ -140,7 +140,7 @@ pub fn load<T: DeserializeOwned>(area: Area) -> Result<Option<T>, StorageError> 
 pub fn init_tab_sync<S: Store + DeserializeOwned>(area: Area) -> Result<(), StorageError> {
     let closure = Closure::wrap(Box::new(move |_: &Event| match load(area) {
         Ok(Some(state)) => {
-            Dispatch::<S>::new().set(state);
+            Dispatch::<S>::global().set(state);
         }
         Err(e) => {
             crate::log::error!("Unable to load state: {:?}", e);

--- a/crates/yewdux/src/store.rs
+++ b/crates/yewdux/src/store.rs
@@ -5,10 +5,12 @@ use async_trait::async_trait;
 
 pub use yewdux_macros::Store;
 
-/// Globally shared state.
+use crate::Context;
+
+/// A type that holds application state.
 pub trait Store: 'static {
     /// Create this store.
-    fn new() -> Self;
+    fn new(cx: &Context) -> Self;
 
     /// Indicate whether or not subscribers should be notified about this change. Usually this
     /// should be set to `self != old`.

--- a/crates/yewdux/src/subscriber.rs
+++ b/crates/yewdux/src/subscriber.rs
@@ -196,7 +196,7 @@ mod tests {
         let dispatch = Dispatch::<TestState>::subscribe(
             move |state: Rc<TestState>| {
                 if state.0 == 0 {
-                    Dispatch::new(&cxo).reduce_mut(|state: &mut TestState| state.0 += 1);
+                    Dispatch::with_cx(&cxo).reduce_mut(|state: &mut TestState| state.0 += 1);
                 }
             },
             &cx,

--- a/crates/yewdux/src/subscriber.rs
+++ b/crates/yewdux/src/subscriber.rs
@@ -58,6 +58,14 @@ pub struct SubscriberId<S: Store> {
     pub(crate) _store_type: PhantomData<S>,
 }
 
+impl<S: Store> std::fmt::Debug for SubscriberId<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SubscriberId")
+            .field("key", &self.key)
+            .finish()
+    }
+}
+
 impl<S: Store> SubscriberId<S> {
     /// Leak this subscription, so it is never dropped.
     pub fn leak(self) {

--- a/crates/yewdux/src/subscriber.rs
+++ b/crates/yewdux/src/subscriber.rs
@@ -4,13 +4,12 @@ use std::{any::Any, marker::PhantomData};
 use slab::Slab;
 use yew::Callback;
 
-use crate::mrc::Mrc;
-use crate::store::Store;
+use crate::{mrc::Mrc, store::Store, Context};
 
 pub(crate) struct Subscribers<S>(pub(crate) Slab<Box<dyn Callable<S>>>);
 
 impl<S: 'static> Store for Subscribers<S> {
-    fn new() -> Self {
+    fn new(_cx: &Context) -> Self {
         Self(Default::default())
     }
 
@@ -107,7 +106,7 @@ mod tests {
     #[derive(Clone, PartialEq, Eq)]
     struct TestState(u32);
     impl Store for TestState {
-        fn new() -> Self {
+        fn new(_cx: &Context) -> Self {
             Self(0)
         }
 

--- a/crates/yewdux/src/subscriber.rs
+++ b/crates/yewdux/src/subscriber.rs
@@ -130,7 +130,7 @@ mod tests {
 
         assert!(entry.store.borrow().borrow().0.is_empty());
 
-        let _id = Dispatch::with_cx(&cx).subscribe(|_: Rc<TestState>| ());
+        let _id = Dispatch::new(&cx).subscribe(|_: Rc<TestState>| ());
 
         assert!(!entry.store.borrow().borrow().0.is_empty());
     }
@@ -142,7 +142,7 @@ mod tests {
 
         assert!(entry.store.borrow().borrow().0.is_empty());
 
-        let id = Dispatch::with_cx(&cx).subscribe(|_: Rc<TestState>| ());
+        let id = Dispatch::new(&cx).subscribe(|_: Rc<TestState>| ());
 
         assert!(!entry.store.borrow().borrow().0.is_empty());
 
@@ -158,7 +158,7 @@ mod tests {
 
         assert!(entry.store.borrow().borrow().0.is_empty());
 
-        let id = Dispatch::<TestState>::with_cx(&cx).subscribe(|_| {});
+        let id = Dispatch::<TestState>::new(&cx).subscribe(|_| {});
 
         assert!(!entry.store.borrow().borrow().0.is_empty());
 
@@ -174,7 +174,7 @@ mod tests {
 
         let _id = {
             let flag = flag.clone();
-            Dispatch::<TestState>::with_cx(&cx)
+            Dispatch::<TestState>::new(&cx)
                 .subscribe(move |_| flag.clone().with_mut(|flag| *flag = true))
         };
 
@@ -204,12 +204,11 @@ mod tests {
     fn can_modify_state_inside_on_changed() {
         let cx = Context::new();
         let cxo = cx.clone();
-        let dispatch =
-            Dispatch::<TestState>::with_cx(&cx).subscribe(move |state: Rc<TestState>| {
-                if state.0 == 0 {
-                    Dispatch::with_cx(&cxo).reduce_mut(|state: &mut TestState| state.0 += 1);
-                }
-            });
+        let dispatch = Dispatch::<TestState>::new(&cx).subscribe(move |state: Rc<TestState>| {
+            if state.0 == 0 {
+                Dispatch::new(&cxo).reduce_mut(|state: &mut TestState| state.0 += 1);
+            }
+        });
 
         assert_eq!(dispatch.get().0, 1)
     }

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -5,5 +5,8 @@ multilingual = false
 src = "src"
 title = "Yewdux"
 
+[rust]
+edition = "2021"
+
 [output.html.playground]
-runnable = false
+runnable = true

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -13,6 +13,8 @@
     - [Persistence](./persistence.md)
 - [Dispatch](./dispatch.md)
     - [Subscriptions](./reading.md)
+- [Contexts](./context.md)
+    - [SSR Support](./ssr.md)
 - [Listeners](./listeners.md)
 - [Tips](./tips.md)
     - [Setting default value](./default_store.md)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -10,11 +10,10 @@
 # Usage
 
 - [Store](./store.md)
+    - [Default value](./default_store.md)
     - [Persistence](./persistence.md)
-- [Dispatch](./dispatch.md)
-    - [Subscriptions](./reading.md)
+- [Writing state](./dispatch.md)
+- [Reading state](./reading.md)
 - [Contexts](./context.md)
     - [SSR Support](./ssr.md)
 - [Listeners](./listeners.md)
-- [Tips](./tips.md)
-    - [Setting default value](./default_store.md)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -14,6 +14,6 @@
     - [Persistence](./persistence.md)
 - [Writing state](./dispatch.md)
 - [Reading state](./reading.md)
+- [Listeners](./listeners.md)
 - [Contexts](./context.md)
     - [SSR Support](./ssr.md)
-- [Listeners](./listeners.md)

--- a/docs/src/context.md
+++ b/docs/src/context.md
@@ -6,6 +6,11 @@ You can easily create and use a local context by instantiating with `Context::ne
 dispatch using your new context.
 
 ```rust
+# extern crate yew;
+# extern crate yewdux;
+use yew::prelude::*;
+use yewdux::prelude::*;
+
 #[derive(Clone, PartialEq, Default, Store)]
 struct Counter(u32);
 
@@ -16,6 +21,10 @@ let dispatch = Dispatch::<Counter>::new(&cx);
 Changes to one context are not reflected in any others:
 
 ```rust
+# extern crate yewdux;
+# use yewdux::prelude::*;
+# #[derive(Clone, PartialEq, Default, Store)]
+# struct Counter(u32);
 let cx_1 = yewdux::Context::new();
 let dispatch_1 = Dispatch::<Counter>::new(&cx_1);
 
@@ -35,6 +44,10 @@ dispatch with `Dispatch::global`. The global context is thread-local, and can be
 from anywhere.
 
 ```rust
+# extern crate yewdux;
+# use yewdux::prelude::*;
+# #[derive(Clone, PartialEq, Default, Store)]
+# struct Counter(u32);
 // These are equivalent!
 let dispatch_1 = Dispatch::<Counter>::global();
 let dispatch_2 = Dispatch::<Counter>::new(&yewdux::Context::global());
@@ -44,7 +57,7 @@ dispatch_1.set(Counter(1));
 assert!(dispatch_1.get() == dispatch_2.get());
 ```
 
-**IMPORTANT**: Use of global context during SSR time is not recommended. See [ssr support](./ssr.md)
+**IMPORTANT**: Use of global context is only supported for wasm targets. See [ssr support](./ssr.md)
 for more details.
 -------
 

--- a/docs/src/context.md
+++ b/docs/src/context.md
@@ -1,0 +1,50 @@
+# Contexts
+
+A `Context` contains the state of `Store`s.
+
+You can easily create and use a local context by instantiating with `Context::new`, and creating a
+dispatch using your new context.
+
+```rust
+#[derive(Clone, PartialEq, Default, Store)]
+struct Counter(u32);
+
+let cx = yewdux::Context::new();
+let dispatch = Dispatch::<Counter>::new(&cx);
+```
+
+Changes to one context are not reflected in any others:
+
+```rust
+let cx_1 = yewdux::Context::new();
+let dispatch_1 = Dispatch::<Counter>::new(&cx_1);
+
+let cx_2 = yewdux::Context::new();
+let dispatch_2 = Dispatch::<Counter>::new(&cx_2);
+
+dispatch_1.set(Counter(1));
+dispatch_2.set(Counter(2));
+
+assert!(dispatch_1.get() != dispatch_2.get());
+```
+
+# The Global Context
+
+You may already be familar with the global context. This is what you are using when you create a
+dispatch with `Dispatch::global`. The global context is thread-local, and can be accessed easily
+from anywhere.
+
+```rust
+// These are equivalent!
+let dispatch_1 = Dispatch::<Counter>::global();
+let dispatch_2 = Dispatch::<Counter>::new(&yewdux::Context::global());
+
+dispatch_1.set(Counter(1));
+
+assert!(dispatch_1.get() == dispatch_2.get());
+```
+
+**IMPORTANT**: Use of global context during SSR time is not recommended. See [ssr support](./ssr.md)
+for more details.
+-------
+

--- a/docs/src/context.md
+++ b/docs/src/context.md
@@ -1,9 +1,10 @@
 # Contexts
 
-A `Context` contains the state of `Store`s.
+Contexts contains the state of your Stores. You rarely (if ever) need to manage them manually, but
+it's useful to understand how they work.
 
-You can easily create and use a local context by instantiating with `Context::new`, and creating a
-dispatch using your new context.
+You can easily create a new local context with `Context::new`. Then just pass it into a dispatch and
+you have your very own locally managed store!
 
 ```rust
 # extern crate yew;
@@ -37,11 +38,11 @@ dispatch_2.set(Counter(2));
 assert!(dispatch_1.get() != dispatch_2.get());
 ```
 
-# The Global Context
+## The Global Context
 
 You may already be familar with the global context. This is what you are using when you create a
-dispatch with `Dispatch::global`. The global context is thread-local, and can be accessed easily
-from anywhere.
+dispatch with `Dispatch::global`. The global context is thread-local, meaning you can access it from
+anywhere in your code as long as it's on the same thread (for wasm this is effectively everywhere).
 
 ```rust
 # extern crate yewdux;

--- a/docs/src/default_store.md
+++ b/docs/src/default_store.md
@@ -3,6 +3,8 @@
 The best way to define the default value of your store is by manually implementing `Default`.
 
 ```rust
+# extern crate yewdux;
+# use yewdux::prelude::*;
 #[derive(PartialEq, Store)]
 struct MyStore {
     foo: String,
@@ -17,35 +19,65 @@ impl Default for MyStore {
         }
     }
 }
-
 ```
 
-However sometimes you may need additional context to set the initial value of your store. To do
-this, there are a couple options.
+Sometimes you may need additional context to set the initial value of your store. To do this, there
+are a couple options.
 
 You can set the value at the beginning of your application, before your app renders (like in your
-main fn).
+main function).
 
 ```rust
+# extern crate yewdux;
+# use yewdux::prelude::*;
+# #[derive(PartialEq, Store, Default)]
+# struct MyStore {
+#     foo: String,
+#     bar: String,
+# }
 fn main() {
-    // .. other setup logic and whatnot
-    Dispatch::<MyStore>::global().set(MyStore { ... });
-    // ... now you can render your app!
+    // Construct foo and bar however necessary
+    let foo = "foo".to_string();
+    let bar = "bar".to_string();
+    // Run this before starting your app.
+    Dispatch::<MyStore>::global().set(MyStore { foo, bar });
+    // ... continue with your app setup
 }
 ```
 
-Or inside some component using `use_effect_with_deps`, provided deps of `()`. Be sure to keep it in
-a root component!
+You can also set the inital value from a function component. The `use_effect_with` hook can be used
+to run the hook only once (just be sure to use empty deps).
 
 ```rust
-use_effect_with_deps(
-    move || {
-        // .. other setup logic and whatnot
-        Dispatch::<MyStore>::global().set(MyStore { ... });
-        || {}
-    },
-    (),
-);
+# extern crate yew;
+# extern crate yewdux;
+#
+# use yewdux::prelude::*;
+# use yew::prelude::*;
+# #[derive(PartialEq, Store, Default)]
+# struct MyStore {
+#     foo: String,
+#     bar: String,
+# }
+#[function_component]
+fn MyComponent() -> Html {
+    let dispatch = use_dispatch::<MyStore>();
+    // This runs only once, on the first render of the component.
+    use_effect_with(
+        (), // empty deps
+        move |_| {
+            // Construct foo and bar however necessary
+            let foo = "foo".to_string();
+            let bar = "bar".to_string();
+            dispatch.set(MyStore { foo, bar });
+            || {}
+        },
+    );
+
+    html! {
+        // Your component html
+    }
+}
 ```
 
 Keep in mind your store will still be initialized with `Store::new` (usually that's set to

--- a/docs/src/default_store.md
+++ b/docs/src/default_store.md
@@ -29,7 +29,7 @@ main fn).
 ```rust
 fn main() {
     // .. other setup logic and whatnot
-    Dispatch::<MyStore>::new().set(MyStore { ... });
+    Dispatch::<MyStore>::global().set(MyStore { ... });
     // ... now you can render your app!
 }
 ```
@@ -41,7 +41,7 @@ a root component!
 use_effect_with_deps(
     move || {
         // .. other setup logic and whatnot
-        Dispatch::<MyStore>::new().set(MyStore { ... });
+        Dispatch::<MyStore>::global().set(MyStore { ... });
         || {}
     },
     (),
@@ -49,5 +49,4 @@ use_effect_with_deps(
 ```
 
 Keep in mind your store will still be initialized with `Store::new` (usually that's set to
-`Default::default()`), however, because Rust is awesome, no fields are allocated initially, and
-overwriting is very cheap.
+`Default::default()`), however this is typically inexpensive.

--- a/docs/src/dispatch.md
+++ b/docs/src/dispatch.md
@@ -1,7 +1,7 @@
 # Dispatch
 
-A [Dispatch](https://docs.rs/yewdux/0.8.1/yewdux/dispatch/struct.Dispatch.html) is the primary
-interface to [Store](https://docs.rs/yewdux/0.8.1/yewdux/store/trait.Store.html). It is used to
+A [Dispatch](https://docs.rs/yewdux/latest/yewdux/dispatch/struct.Dispatch.html) is the primary
+interface to [Store](https://docs.rs/yewdux/latest/yewdux/store/trait.Store.html). It is used to
 read and write changes to state in various ways.
 
 # Creating a Dispatch
@@ -18,7 +18,7 @@ A dispatch is also given when using the functional hook.
 let (state, dispatch) = use_store::<Counter>();
 ```
 
-# Changing global state with Dispatch
+# Changing state
 
 `Dispatch` provides many options for changing state.
 

--- a/docs/src/dispatch.md
+++ b/docs/src/dispatch.md
@@ -1,142 +1,154 @@
-# Dispatch
+# Creating a dispatch
 
 A [Dispatch](https://docs.rs/yewdux/latest/yewdux/dispatch/struct.Dispatch.html) is the primary
-interface to [Store](https://docs.rs/yewdux/latest/yewdux/store/trait.Store.html). It is used to
-read and write changes to state in various ways.
+interface to access your [Store](https://docs.rs/yewdux/latest/yewdux/store/trait.Store.html). It
+can be used to read and write changes to state in various ways.
 
-# Creating a Dispatch
+## Hooks
+
+A dispatch is provided when using the functional hook, which is only available in yew functional
+components.
+
+**IMPORTANT**: Like other hooks, all yewdux hooks must be used at the top level of a function
+component.
+
+```rust
+# extern crate yewdux;
+# extern crate yew;
+# use yewdux::prelude::*;
+# use yew::prelude::*;
+#[derive(Default, PartialEq, Store)]
+struct State {
+    count: u32,
+}
+
+#[function_component]
+fn MyComponent() -> Html {
+    let (state, dispatch) = use_store::<State>();
+    html! {
+        // Component stuff here
+    }
+}
+```
+
+See [the docs](https://docs.rs/yewdux/latest/yewdux/functional/index.html) for a full list of
+available hooks.
+
+## Manually
 
 To create a dispatch, you need only provide the desired store type. This is available in **any**
 rust code, not just yew components.
 
 ```rust
-let dispatch = Dispatch::<Counter>::new();
+# extern crate yewdux;
+# use yewdux::prelude::*;
+# #[derive(Default, PartialEq, Store)]
+# struct State {
+#     count: u32,
+# }
+let dispatch = Dispatch::<State>::global();
 ```
 
-A dispatch is also given when using the functional hook, which is only available in yew functional
-components.
-
-**IMPORTANT**: `use_store` is a functional hook, and must be used at the top level of a function
-component.
-
-```rust
-let (state, dispatch) = use_store::<Counter>();
-```
+**NOTE**: Here we create a global dispatch, which is only available for wasm targets. See
+[SSR support](./ssr.md) for alternatives.
 
 # Changing state
 
-`Dispatch` provides many options for changing state.
+`Dispatch` provides many options for changing state. Here are a few handy methods. For a full list
+see the [docs](https://docs.rs/yewdux/latest/yewdux/dispatch/struct.Dispatch.html#)
 
-### `Dispatch::set`
-
-Assign the store to the given value.
 
 ```rust
-dispatch.set(Counter { count: 0 });
-```
-
-### `Dispatch::set_callback`
-
-Generate a callback that will set the store to a given value.
-
-```rust
-let onclick = dispatch.set_callback(|_| Counter { count: 0 });
-html! {
-    <button {onclick}>{"Reset counter"}</button>
+# extern crate yewdux;
+# extern crate yew;
+# use yewdux::prelude::*;
+# use yew::prelude::*;
+#[derive(Default, PartialEq, Store)]
+struct State {
+    count: u32,
 }
-```
 
-### `Dispatch::reduce`
+// Create a global dispatch
+let dispatch = Dispatch::<State>::global();
 
-Assign the state of the store using a reducer function.
+// Set the value immediately
+dispatch.set(State { count: 0 });
 
-```rust
-dispatch.reduce(|counter| Counter { count: counter.count + 1});
-```
+// Set the value immediately based on the last value
+dispatch.reduce(|state| State { count: state.count + 1}.into());
 
-### `Dispatch::reduce_callback`
-
-Generate a callback that assigns state using a reducer function.
-
-```rust
-let onclick = dispatch.reduce_callback(|counter| Counter { count: counter.count + 1});
+// Create a callback to set the value when a button is clicked
+let onclick = dispatch.reduce_callback(|state| State { count: state.count + 1}.into());
 html! {
     <button {onclick}>{"Increment (+1)"}</button>
-}
+};
 ```
 
-### `Dispatch::reduce_callback_with`
-
-Similar to `Dispatch::reduce_callback`, but also includes the fired event.
-
-```rust
-let onchange = dispatch.reduce_callback_with(|counter, e: Event| {
-    let input = e.target_unchecked_into::<HtmlInputElement>();
-
-    if let Ok(count) = input.value().parse() {
-        Counter { count }.into()
-    } else {
-        counter
-    }
-});
-
-html! {
-    <input placeholder="Set counter" {onchange} />
-}
-```
-
-# Mutation with less boilerplate (CoW)
+## Mut reducers
 
 There are `_mut` variants to every reducer function. This way has less boilerplate, and requires
-your `Store` to implement `Clone`.
-
-### `Dispatch::reduce_mut`
+your `Store` to implement `Clone`. Your `Store` *may* be cloned once per mutation,
 
 ```rust
-dispatch.reduce_mut(|counter| counter.count += 1);
-```
+# extern crate yewdux;
+# extern crate yew;
+# use yewdux::prelude::*;
+# use yew::prelude::*;
+#[derive(Default, PartialEq, Clone, Store)]
+struct State {
+    count: u32,
+}
 
-### `Dispatch::reduce_mut_callback`
+// Create a global dispatch
+let dispatch = Dispatch::<State>::global();
 
-```rust
+// Mutate the current value
+dispatch.reduce_mut(|state| state.count += 1);
+
+// Create a callback to mutate the value when a button is clicked
 let onclick = dispatch.reduce_mut_callback(|counter| counter.count += 1);
 html! {
     <button {onclick}>{"Increment (+1)"}</button>
-}
+};
 ```
 
-### `Dispatch::reduce_mut_callback_with`
-
-```rust
-let onchange = dispatch.reduce_mut_callback_with(|counter, e: Event| {
-    let input = e.target_unchecked_into::<HtmlInputElement>();
-
-    if let Ok(val) = input.value().parse() {
-        counter.count = val;
-    }
-});
-
-html! {
-    <input placeholder="Set counter" {onchange} />
-}
-```
-
-# Mutate state predictably
+## Predictable mutations
 
 Yewdux supports predictable mutation. Simply define your message and apply it.
 
 ```rust
-struct Msg {
+# extern crate yewdux;
+# extern crate yew;
+use std::rc::Rc;
+
+use yew::prelude::*;
+use yewdux::prelude::*;
+
+#[derive(Default, PartialEq, Clone, Store)]
+struct State {
+    count: u32,
+}
+
+enum Msg {
     AddOne,
 }
 
-impl Reducer<Counter> for Msg {
-    fn apply(self, counter: Rc<Counter>) -> Rc<Counter> {
+impl Reducer<State> for Msg {
+    fn apply(self, state: Rc<State>) -> Rc<State> {
         match self {
-            Msg::AddOne => Counter { count: counter.count + 1 },
+            Msg::AddOne => State { count: state.count + 1 }.into(),
         }
     }
 }
+
+let dispatch = Dispatch::<State>::global();
+
+dispatch.apply(Msg::AddOne);
+
+let onclick = dispatch.apply_callback(|_| Msg::AddOne);
+html! {
+    <button {onclick}>{"Increment (+1)"}</button>
+};
 ```
 
 ### Tip
@@ -144,106 +156,55 @@ impl Reducer<Counter> for Msg {
 `Rc::make_mut` is handy if you prefer CoW:
 
 ```rust
-impl Reducer<Counter> for Msg {
-    fn apply(self, mut counter: Rc<Counter>) -> Rc<Counter> {
-        let state = Rc::make_mut(&mut counter);
+# extern crate yewdux;
+# use std::rc::Rc;
+# use yewdux::prelude::*;
+# #[derive(Default, PartialEq, Clone, Store)]
+# struct State {
+#     count: u32,
+# }
+# enum Msg {
+#     AddOne,
+# }
+impl Reducer<State> for Msg {
+    fn apply(self, mut state: Rc<State>) -> Rc<State> {
+        let state_mut = Rc::make_mut(&mut state);
 
         match self {
-            Msg::AddOne => state.count += 1,
+            Msg::AddOne => state_mut.count += 1,
         };
 
-        counter
+        state
     }
 }
 ```
 
-
-### `Dispatch::apply`
-
-Execute immediately.
-
-```rust
-dispatch.apply(Msg::AddOne);
-```
-
-### `Dispatch::apply_callback`
-
-Generate (you guessed it) a callback.
-
-```rust
-let onclick = dispatch.apply_callback(|_| Msg::AddOne);
-html! {
-    <button {onclick}>{"Increment (+1)"}</button>
-}
-```
-
-# Future support
+## Future support
 
 Because a `Dispatch` may be created and executed from anywhere, Yewdux has innate future support.
 Just use it normally, no additonal setup is needed.
 
 ```rust
-yew::platform::spawn_local(async {
+# extern crate yewdux;
+# extern crate yew;
+# use std::rc::Rc;
+# use yewdux::prelude::*;
+# use yew::prelude::*;
+
+#[derive(Default, PartialEq, Store)]
+struct User {
+    name: Option<Rc<str>>,
+}
+
+async fn get_user() -> User {
+    User { name: Some("bob".into()) }
+}
+
+let dispatch = Dispatch::<User>::global();
+// Use yew::platform::spawn_local to run a future.
+let future = async move {
     let user = get_user().await;
-    Dispatch::<User>::global().set(user);
-})
+    dispatch.set(user);
+};
 ```
 
-## Async associated functions
-For stores that have async methods, dispatch provides some options for your convenience.
-
-### `Dispatch::reduce_future`
-
-Executes immediately.
-
-```rust
-dispatch
-    .reduce_future(|state| async move {
-        let mut state = state.as_ref().clone();
-        state.update_user().await;
-
-        state
-    })
-    .await;
-```
-
-### `Dispatch::reduce_mut_future`
-
-For the `CoW` approach. Note `Box::pin` is required here. This is due to a current limitation of
-Rust's type system, and should be phased out in the future.
-
-```rust
-dispatch
-    .reduce_mut_future(|state| {
-        Box::pin(async move {
-            state.update_user().await;
-        })
-    })
-    .await;
-```
-
-## Async callbacks
-
-You can also create callbacks that execute a future when called. Note these are simple wrappers over
-`yew::platform::spawn_local`.
-
-### `Dispatch::reduce_future_callback`
-
-```rust
-let cb = dispatch.reduce_future_callback(|state| async move {
-    let mut state = state.as_ref().clone();
-    state.update_user().await;
-
-    state
-});
-```
-
-### `Dispatch::reduce_mut_future_callback`
-
-```rust
-let cb = dispatch.reduce_mut_future_callback(|state| {
-    Box::pin(async move {
-        state.update_user().await;
-    })
-});
-```

--- a/docs/src/dispatch.md
+++ b/docs/src/dispatch.md
@@ -6,13 +6,18 @@ read and write changes to state in various ways.
 
 # Creating a Dispatch
 
-To create a dispatch, you need only provide the desired store type. This is available in **any** rust code, not just yew components.
+To create a dispatch, you need only provide the desired store type. This is available in **any**
+rust code, not just yew components.
 
 ```rust
-let dispatch = Dispatch::<Counter>::global();
+let dispatch = Dispatch::<Counter>::new();
 ```
 
-A dispatch is also given when using the functional hook, which is only available in yew components.
+A dispatch is also given when using the functional hook, which is only available in yew functional
+components.
+
+**IMPORTANT**: `use_store` is a functional hook, and must be used at the top level of a function
+component.
 
 ```rust
 let (state, dispatch) = use_store::<Counter>();

--- a/docs/src/dispatch.md
+++ b/docs/src/dispatch.md
@@ -9,7 +9,7 @@ read and write changes to state in various ways.
 To create a dispatch, you need only provide the desired store type.
 
 ```rust
-let dispatch = Dispatch::<Counter>::new();
+let dispatch = Dispatch::<Counter>::global();
 ```
 
 A dispatch is also given when using the functional hook.
@@ -180,7 +180,7 @@ Just use it normally, no additonal setup is needed.
 ```rust
 yew::platform::spawn_local(async {
     let user = get_user().await;
-    Dispatch::<User>::new().set(user);
+    Dispatch::<User>::global().set(user);
 })
 ```
 
@@ -205,7 +205,7 @@ dispatch
 ### `Dispatch::reduce_mut_future`
 
 For the `CoW` approach. Note `Box::pin` is required here. This is due to a current limitation of
-Rust, and should be phased out in the future.
+Rust's type system, and should be phased out in the future.
 
 ```rust
 dispatch

--- a/docs/src/example.md
+++ b/docs/src/example.md
@@ -34,7 +34,7 @@ fn main() {
 ## Additional examples
 
 Complete working examples can be found in the
-[examples](https://github.com/intendednull/yewdux/tree/0.8.1/examples) folder of github.
+[examples](https://github.com/intendednull/yewdux/tree/master/examples) folder of github.
 
 To run an example you'll need to install [trunk](https://github.com/thedodd/trunk) (a rust wasm
 bundler), then run the following command (replacing [example] with your desired example name):

--- a/docs/src/example.md
+++ b/docs/src/example.md
@@ -1,33 +1,42 @@
 # Quickstart example
 
 Below you'll find a simple counter example, demonstrating how to read and write to shared state.
-Only one component is shown here for simplicity, however keep in mind every other component that
-uses the same `Counter` store type will share its state!
 
 ```rust
+# extern crate yewdux;
+# extern crate yew;
 use yew::prelude::*;
 use yewdux::prelude::*;
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, Store)]
-struct Counter {
+#[derive(Debug, Default, Clone, PartialEq, Store)]
+struct State {
     count: u32,
 }
 
 #[function_component]
-fn App() -> Html {
-    let (counter, dispatch) = use_store::<Counter>();
+fn ViewCount() -> Html {
+    let (state, _) = use_store::<State>();
+    html!(state.count)
+}
+
+#[function_component]
+fn IncrementCount() -> Html {
+    let (_, dispatch) = use_store::<State>();
     let onclick = dispatch.reduce_mut_callback(|counter| counter.count += 1);
 
     html! {
-        <>
-        <p>{ counter.count }</p>
         <button {onclick}>{"+1"}</button>
-        </>
     }
 }
 
-fn main() {
-    yew::Renderer::<App>::new().render();
+#[function_component]
+fn App() -> Html {
+    html! {
+        <>
+        <ViewCount />
+        <IncrementCount />
+        </>
+    }
 }
 ```
 
@@ -38,5 +47,6 @@ Complete working examples can be found in the
 
 To run an example you'll need to install [trunk](https://github.com/thedodd/trunk) (a rust wasm
 bundler), then run the following command (replacing [example] with your desired example name):
-
+```bash
     trunk serve examples/[example]/index.html --open
+```

--- a/docs/src/example.md
+++ b/docs/src/example.md
@@ -8,7 +8,7 @@ Below you'll find a simple counter example, demonstrating how to read and write 
 use yew::prelude::*;
 use yewdux::prelude::*;
 
-#[derive(Debug, Default, Clone, PartialEq, Store)]
+#[derive(Default, Clone, PartialEq, Store)]
 struct State {
     count: u32,
 }

--- a/docs/src/listeners.md
+++ b/docs/src/listeners.md
@@ -16,7 +16,7 @@ impl Listener for StorageListener {
     // Here's where we say which store we want to subscribe to.
     type Store = State;
 
-    fn on_change(&mut self, state: Rc<Self::Store>) {
+    fn on_change(&mut self, _cx: &yewdux::Context, state: Rc<Self::Store>) {
         storage::save(state.as_ref(), storage::Area::Local).expect("unable to save state");
     }
 }
@@ -35,8 +35,8 @@ struct State {
 }
 
 impl Store for State {
-    fn new() -> Self {
-        init_listener(StorageListener, &yewdux::Context::global());
+    fn new(cx: &yewdux::Context) -> Self {
+        init_listener(StorageListener, cx);
 
         storage::load(storage::Area::Local)
             .ok()

--- a/docs/src/listeners.md
+++ b/docs/src/listeners.md
@@ -3,45 +3,62 @@
 Listeners are component-less subscribers. They are used to describe side-effects that should happen
 whenever state changes. They live for application lifetime, and are created with `init_listener`.
 
-To see how this is useful, let's recreate store [persistence](./persistence.md). The full example can
-be seen [here](https://github.com/intendednull/yewdux/blob/master/examples/listener/src/main.rs).
-
-First we define `StorageListener`. Its implementation is super simple: whenever state changes we
-save it to local storage.
-
+Here's a simple listener that logs the current state whenever it changes.
 ```rust
-// Doesn't hold any state, so we'll use an empty type.
-struct StorageListener;
-impl Listener for StorageListener {
-    // Here's where we say which store we want to subscribe to.
-    type Store = State;
+# extern crate yew;
+# extern crate yewdux;
+# use yew::prelude::*;
+use std::rc::Rc;
 
+use yewdux::prelude::*;
+
+#[derive(Default, Clone, PartialEq, Debug, Store)]
+struct State {
+    count: u32,
+}
+
+// The listener itself doesn't hold any state in this case, so we'll use an empty type. It's also
+// possible to have stateful listeners.
+struct StateLogger;
+impl Listener for StateLogger {
+    // Here's where we define which store we are listening to.
+    type Store = State;
+    // Here's where we decide what happens when `State` changes.
     fn on_change(&mut self, _cx: &yewdux::Context, state: Rc<Self::Store>) {
-        storage::save(state.as_ref(), storage::Area::Local).expect("unable to save state");
+        yewdux::log::info!("state changed: {:?}", state);
     }
 }
 ```
 
-Now we define our store. To initialize `StorageListener`, we call `init_listener(StorageListener)`
-in the `Store::new` method. This ensures it is always created along with `State`.
+Can can start the listener by calling `init_listener` somewhere in our code. A good place to put it is
+the store constructor.
 
 **NOTE**: Successive calls to `init_listener` on the same type will replace the existing listener
 with the new one.
 
 ```rust
-#[derive(Default, Clone, PartialEq, Eq, Deserialize, Serialize)]
-struct State {
-    count: u32,
-}
+# extern crate yewdux;
+# use std::rc::Rc;
+# use yewdux::prelude::*;
+# #[derive(Default, PartialEq, Debug)]
+# struct State {
+#     count: u32,
+# }
+# // Doesn't hold any state, so we'll use an empty type.
+# struct StateLogger;
+# impl Listener for StateLogger {
+#     // Here's where we say which store we want to subscribe to.
+#     type Store = State;
+#
+#     fn on_change(&mut self, _cx: &yewdux::Context, state: Rc<Self::Store>) {
+#         yewdux::log::info!("state changed: {:?}", state);
+#     }
+# }
 
 impl Store for State {
     fn new(cx: &yewdux::Context) -> Self {
-        init_listener(StorageListener, cx);
-
-        storage::load(storage::Area::Local)
-            .ok()
-            .flatten()
-            .unwrap_or_default()
+        init_listener(StateLogger, cx);
+        Default::default()
     }
 
     fn should_notify(&self, other: &Self) -> bool {
@@ -50,24 +67,3 @@ impl Store for State {
 }
 ```
 
-Finally we use the store normally. If all goes well, your counter will now persist through page
-visits!
-
-```rust
-#[function_component]
-fn App() -> Html {
-    let (state, dispatch) = use_store::<State>();
-    let onclick = dispatch.reduce_mut_callback(|state| state.count += 1);
-
-    html! {
-        <>
-        <p>{ state.count }</p>
-        <button {onclick}>{"+1"}</button>
-        </>
-    }
-}
-
-fn main() {
-    yew::Renderer::<App>::new().render();
-}
-```

--- a/docs/src/listeners.md
+++ b/docs/src/listeners.md
@@ -36,7 +36,7 @@ struct State {
 
 impl Store for State {
     fn new() -> Self {
-        init_listener(StorageListener);
+        init_listener(StorageListener, &yewdux::Context::global());
 
         storage::load(storage::Area::Local)
             .ok()

--- a/docs/src/persistence.md
+++ b/docs/src/persistence.md
@@ -20,7 +20,8 @@ use yewdux::{prelude::*, storage};
 
 impl Store for Counter {
     fn new() -> Self {
-        init_listener(storage::StorageListener::<Self>::new(storage::Area::Local));
+        let cx = yewdux::Context::global();
+        init_listener(storage::StorageListener::<Self>::new(storage::Area::Local), &cx);
 
         storage::load(storage::Area::Local)
             .expect("Unable to load state")

--- a/docs/src/persistence.md
+++ b/docs/src/persistence.md
@@ -3,35 +3,20 @@
 Yewdux provides the `#[store]` macro to easily persist your state in either local or session storage.
 
 ```rust
+# extern crate yewdux;
+# extern crate serde;
 use yewdux::prelude::*;
 use serde::{Serialize, Deserialize};
 
 #[derive(Default, PartialEq, Serialize, Deserialize, Store)]
 #[store(storage = "local")] // can also be "session"
-struct Counter {
+struct State {
     count: u32,
 }
 ```
 
-This can also be done manually.
-
-```rust
-use yewdux::{prelude::*, storage};
-
-impl Store for Counter {
-    fn new(cx: &yewdux::Context) -> Self {
-        init_listener(storage::StorageListener::<Self>::new(storage::Area::Local), cx);
-
-        storage::load(storage::Area::Local)
-            .expect("Unable to load state")
-            .unwrap_or_default()
-    }
-
-    fn should_notify(&self, other: &Self) -> bool {
-        self != other
-    }
-}
-```
+This can also be done
+[manually](https://github.com/intendednull/yewdux/blob/master/examples/listener/src/main.rs).
 
 ## Tab sync
 
@@ -39,6 +24,10 @@ Normally if your application is open in multiple tabs, the store is not updated 
 than the current one. If you want storage to sync in all tabs, add `storage_tab_sync` to the macro.
 
 ```rust
+# extern crate yewdux;
+# extern crate serde;
+# use yewdux::prelude::*;
+# use serde::{Serialize, Deserialize};
 #[derive(Default, Clone, PartialEq, Eq, Deserialize, Serialize, Store)]
 #[store(storage = "local", storage_tab_sync)]
 struct State {
@@ -51,6 +40,11 @@ struct State {
 You can inject additional listeners into the `#[store]` macro.
 
 ```rust
+# extern crate yewdux;
+# extern crate serde;
+# use std::rc::Rc;
+# use yewdux::prelude::*;
+# use serde::{Serialize, Deserialize};
 #[derive(Default, Clone, PartialEq, Eq, Deserialize, Serialize, Store)]
 #[store(storage = "local", listener(LogListener))]
 struct State {
@@ -61,8 +55,8 @@ struct LogListener;
 impl Listener for LogListener {
     type Store = State;
 
-    fn on_change(&mut self, state: Rc<Self::Store>) {
-        log!(Level::Info, "Count changed to {}", state.count);
+    fn on_change(&mut self, _cx: &yewdux::Context, state: Rc<Self::Store>) {
+        yewdux::log::info!("Count changed to {}", state.count);
     }
 }
 ```

--- a/docs/src/persistence.md
+++ b/docs/src/persistence.md
@@ -19,9 +19,8 @@ This can also be done manually.
 use yewdux::{prelude::*, storage};
 
 impl Store for Counter {
-    fn new() -> Self {
-        let cx = yewdux::Context::global();
-        init_listener(storage::StorageListener::<Self>::new(storage::Area::Local), &cx);
+    fn new(cx: &yewdux::Context) -> Self {
+        init_listener(storage::StorageListener::<Self>::new(storage::Area::Local), cx);
 
         storage::load(storage::Area::Local)
             .expect("Unable to load state")

--- a/docs/src/reading.md
+++ b/docs/src/reading.md
@@ -43,7 +43,7 @@ impl Component for MyComponent {
         let callback = ctx.link().callback(Msg::UpdateCounter);
         // Subscribe to changes in state. New state is received in `update`. Be sure to save this,
         // dropping it will unsubscribe.
-        let dispatch = Dispatch::<Counter>::subscribe(callback);
+        let dispatch = Dispatch::<Counter>::subscribe_global(callback);
         Self {
             // Get the current state.
             counter: dispatch.get(),

--- a/docs/src/setup.md
+++ b/docs/src/setup.md
@@ -6,8 +6,8 @@ Add Yewdux to your project's `Cargo.toml`. Make sure Yew has the "csr" feature (
 
 ```toml
 [dependencies]
-yew = { version = "0.20", features = ["csr"] }
-yewdux = "0.9"
+yew = { version = "0.21", features = ["csr"] }
+yewdux = "0.10"
 ```
 
 ### Development branch:

--- a/docs/src/ssr.md
+++ b/docs/src/ssr.md
@@ -1,0 +1,47 @@
+# SSR Support
+
+The global context is thread-local, meaning it is shared by everything in the same thread. In a web
+environment (strictly single-threaded), this effectively means app-wide shared state. However during
+SSR time, this isn't always true. In fact, **using the global context during SSR time can be
+unsafe**. For example if user details are saved in global context during SSR time of one session,
+they could accidentally *leak* into every other active session in that thread.
+
+To avoid accidental leakage, use Yewdux's dedicated context provider `YewduxRoot`:
+
+```rust
+use yew::prelude::*;
+use yewdux::prelude::*;
+
+#[derive(Default, Clone, PartialEq, Eq, Store)]
+struct State {
+    count: u32,
+}
+
+#[function_component]
+fn Counter() -> Html {
+    let (state, dispatch) = use_store::<State>();
+    let onclick = dispatch.reduce_mut_callback(|state| state.count += 1);
+    html! {
+        <>
+        <p>{ state.count }</p>
+        <button {onclick}>{"+1"}</button>
+        </>
+    }
+}
+
+#[function_component]
+fn App() -> Html {
+    html! {
+        <YewduxRoot>
+            <Counter />
+        </YewduxRoot>
+    }
+}
+```
+
+Hooks will detect the context provided by YewduxRoot. If no root is provided, the global context is
+used.
+
+For struct component support, refer to the [higher order components
+pattern](https://yew.rs/docs/advanced-topics/struct-components/hoc).
+

--- a/docs/src/ssr.md
+++ b/docs/src/ssr.md
@@ -1,14 +1,21 @@
 # SSR Support
 
-The global context is thread-local, meaning it is shared by everything in the same thread. In a web
-environment (strictly single-threaded), this effectively means app-wide shared state. However during
-SSR time, this isn't always true. In fact, **using the global context during SSR time can be
-unsafe**. For example if user details are saved in global context during SSR time of one session,
-they could accidentally *leak* into every other active session in that thread.
+By default Yewdux uses a global `Context` that is shared thread-locally. This means we can share
+state from anywhere in our code as long as it's within the same thread. Wasm applications are
+strictly single threaded (without workers), so it isn't a problem.
 
-To avoid accidental leakage, use Yewdux's dedicated context provider `YewduxRoot`:
+However the same cannot be said for server side rendering. It is very possible the server is
+executing in a multi-threaded environment, which could cause various problems for Yewdux's
+single-threaded assumption.
+
+While multi-threaded globally shared state is technically possible, it is currently not supported.
+
+Instead Yewdux offers a custom component to hold your shared application state: `YewduxRoot`. This
+ensures all state is kept inside your Yew app.
 
 ```rust
+# extern crate yew;
+# extern crate yewdux;
 use yew::prelude::*;
 use yewdux::prelude::*;
 
@@ -31,6 +38,7 @@ fn Counter() -> Html {
 
 #[function_component]
 fn App() -> Html {
+    // YewduxRoot must be kept above all components that use any of your stores.
     html! {
         <YewduxRoot>
             <Counter />
@@ -39,9 +47,92 @@ fn App() -> Html {
 }
 ```
 
-Hooks will detect the context provided by YewduxRoot. If no root is provided, the global context is
-used.
+Yewdux hooks automatically detect when YewduxRoot is present, and us it accordingly.
+
+## SSR with struct components
 
 For struct component support, refer to the [higher order components
 pattern](https://yew.rs/docs/advanced-topics/struct-components/hoc).
 
+```rust
+# extern crate yew;
+# extern crate yewdux;
+use std::rc::Rc;
+
+use yew::prelude::*;
+use yewdux::prelude::*;
+
+#[derive(Default, Clone, PartialEq, Eq, Store)]
+struct State {
+    count: u32,
+}
+
+#[derive(Properties, Clone, PartialEq)]
+struct Props {
+    dispatch: Dispatch<State>,
+}
+
+enum Msg {
+    StateChanged(Rc<State>),
+}
+
+struct MyComponent {
+    state: Rc<State>,
+    dispatch: Dispatch<State>,
+}
+
+impl Component for MyComponent {
+    type Properties = Props;
+    type Message = Msg;
+
+    fn create(ctx: &Context<Self>) -> Self {
+        let callback = ctx.link().callback(Msg::StateChanged);
+        let dispatch = ctx.props().dispatch.clone().subscribe_silent(callback);
+        Self {
+            state: dispatch.get(),
+            dispatch,
+        }
+    }
+
+    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
+        match msg {
+            Msg::StateChanged(state) => {
+                self.state = state;
+                true
+            }
+        }
+    }
+
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let count = self.state.count;
+        let onclick = self.dispatch.reduce_mut_callback(|s| s.count += 1);
+        html! {
+            <>
+            <h1>{ count }</h1>
+            <button onclick={onclick}>{"+1"}</button>
+            </>
+        }
+    }
+
+}
+
+#[function_component]
+fn MyComponentHoc() -> Html {
+    let dispatch = use_dispatch::<State>();
+
+    html! {
+        <MyComponent {dispatch} />
+    }
+}
+
+
+#[function_component]
+fn App() -> Html {
+    // YewduxRoot must be kept above all components that use any of your stores.
+    html! {
+        <YewduxRoot>
+            <MyComponentHoc />
+        </YewduxRoot>
+    }
+}
+```

--- a/docs/src/ssr.md
+++ b/docs/src/ssr.md
@@ -47,7 +47,7 @@ fn App() -> Html {
 }
 ```
 
-Yewdux hooks automatically detect when YewduxRoot is present, and us it accordingly.
+Yewdux hooks automatically detect when YewduxRoot is present, and use it accordingly.
 
 ## SSR with struct components
 

--- a/docs/src/store.md
+++ b/docs/src/store.md
@@ -6,8 +6,11 @@ shared application-wide. It is initialized on first access, and lives for applic
 Implement `Store` for your state using the macro.
 
 ```rust
+# extern crate yewdux;
+use yewdux::prelude::*;
+
 #[derive(Default, PartialEq, Store)]
-struct Counter {
+struct State {
     count: u32,
 }
 ```
@@ -16,13 +19,15 @@ It is also simple to define a `Store` manually. This is useful when you need fin
 it is created, or when to notify components.
 
 ```rust
+# extern crate yewdux;
+# use yewdux::prelude::*;
 #[derive(PartialEq)]
-struct Counter {
+struct State {
     count: u32,
 }
 
-impl Store for Counter {
-    fn new(_cx: &Context) {
+impl Store for State {
+    fn new(_cx: &yewdux::Context) -> Self {
         Self {
             count: Default::default(),
         }

--- a/docs/src/store.md
+++ b/docs/src/store.md
@@ -22,7 +22,7 @@ struct Counter {
 }
 
 impl Store for Counter {
-    fn new() {
+    fn new(_cx: &Context) {
         Self {
             count: Default::default(),
         }

--- a/docs/src/tips.md
+++ b/docs/src/tips.md
@@ -1,1 +1,0 @@
-That about covers basic usage! Now here are various tips and patterns to help you develop your app.

--- a/examples/async_proxy/src/main.rs
+++ b/examples/async_proxy/src/main.rs
@@ -39,7 +39,7 @@ struct TimeProps {
 
 #[function_component]
 fn Time(props: &TimeProps) -> Html {
-    let dispatch = Dispatch::<State>::global();
+    let dispatch = Dispatch::<State>::new();
     let timezone = props.timezone.clone();
     let refresh = {
         let timezone = timezone.clone();
@@ -79,7 +79,7 @@ fn Time(props: &TimeProps) -> Html {
 
 #[function_component]
 fn NewTimeZone() -> Html {
-    let dispatch = Dispatch::<State>::global();
+    let dispatch = Dispatch::<State>::new();
     let onkeypress = dispatch.reduce_mut_callback_with(|state, e: KeyboardEvent| {
         if e.key() == "Enter" {
             let input: web_sys::HtmlInputElement = e.target_unchecked_into();

--- a/examples/async_proxy/src/main.rs
+++ b/examples/async_proxy/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg(target_arch = "wasm32")]
+
 use yew::prelude::*;
 use yewdux::prelude::*;
 

--- a/examples/async_proxy/src/main.rs
+++ b/examples/async_proxy/src/main.rs
@@ -41,7 +41,7 @@ struct TimeProps {
 
 #[function_component]
 fn Time(props: &TimeProps) -> Html {
-    let dispatch = Dispatch::<State>::new();
+    let dispatch = Dispatch::<State>::global();
     let timezone = props.timezone.clone();
     let refresh = {
         let timezone = timezone.clone();
@@ -81,7 +81,7 @@ fn Time(props: &TimeProps) -> Html {
 
 #[function_component]
 fn NewTimeZone() -> Html {
-    let dispatch = Dispatch::<State>::new();
+    let dispatch = Dispatch::<State>::global();
     let onkeypress = dispatch.reduce_mut_callback_with(|state, e: KeyboardEvent| {
         if e.key() == "Enter" {
             let input: web_sys::HtmlInputElement = e.target_unchecked_into();

--- a/examples/async_proxy/src/main.rs
+++ b/examples/async_proxy/src/main.rs
@@ -39,7 +39,7 @@ struct TimeProps {
 
 #[function_component]
 fn Time(props: &TimeProps) -> Html {
-    let dispatch = Dispatch::<State>::new();
+    let dispatch = Dispatch::<State>::global();
     let timezone = props.timezone.clone();
     let refresh = {
         let timezone = timezone.clone();
@@ -79,7 +79,7 @@ fn Time(props: &TimeProps) -> Html {
 
 #[function_component]
 fn NewTimeZone() -> Html {
-    let dispatch = Dispatch::<State>::new();
+    let dispatch = Dispatch::<State>::global();
     let onkeypress = dispatch.reduce_mut_callback_with(|state, e: KeyboardEvent| {
         if e.key() == "Enter" {
             let input: web_sys::HtmlInputElement = e.target_unchecked_into();

--- a/examples/async_proxy/src/proxy.rs
+++ b/examples/async_proxy/src/proxy.rs
@@ -38,7 +38,7 @@ impl State {
         }
 
         yew::platform::spawn_local(async move {
-            let dispatch = Dispatch::<State>::new();
+            let dispatch = Dispatch::<State>::global();
             let response = {
                 let url = "http://worldtimeapi.org/api/timezone/".to_string() + timezone.as_str();
                 Request::get(&url).send().await

--- a/examples/async_proxy/src/proxy.rs
+++ b/examples/async_proxy/src/proxy.rs
@@ -38,7 +38,7 @@ impl State {
         }
 
         yew::platform::spawn_local(async move {
-            let dispatch = Dispatch::<State>::global();
+            let dispatch = Dispatch::<State>::new();
             let response = {
                 let url = "http://worldtimeapi.org/api/timezone/".to_string() + timezone.as_str();
                 Request::get(&url).send().await

--- a/examples/context_root/Cargo.toml
+++ b/examples/context_root/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "context_root"
+version = "0.1.0"
+authors = ["Noah <noah@coronasoftware.net>"]
+edition = "2018"
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+yew = { git = "https://github.com/yewstack/yew.git", features = ["csr"] }
+yewdux = { path = "../../crates/yewdux" }

--- a/examples/context_root/index.html
+++ b/examples/context_root/index.html
@@ -1,0 +1,4 @@
+<html>
+  <head>
+  </head>
+</html>

--- a/examples/context_root/src/main.rs
+++ b/examples/context_root/src/main.rs
@@ -8,7 +8,7 @@ struct State {
 
 #[function_component]
 fn Counter() -> Html {
-    let global_state = Dispatch::<State>::global().get();
+    let global_state = Dispatch::<State>::new().get();
     let (state, dispatch) = use_store::<State>();
     let onclick = dispatch.reduce_mut_callback(|state| state.count += 1);
     html! {

--- a/examples/context_root/src/main.rs
+++ b/examples/context_root/src/main.rs
@@ -8,7 +8,7 @@ struct State {
 
 #[function_component]
 fn Counter() -> Html {
-    let global_state = Dispatch::<State>::new().get();
+    let global_state = Dispatch::<State>::global().get();
     let (state, dispatch) = use_store::<State>();
     let onclick = dispatch.reduce_mut_callback(|state| state.count += 1);
     html! {

--- a/examples/context_root/src/main.rs
+++ b/examples/context_root/src/main.rs
@@ -1,0 +1,34 @@
+use yew::prelude::*;
+use yewdux::prelude::*;
+
+#[derive(Default, Clone, PartialEq, Eq, Store)]
+struct State {
+    count: u32,
+}
+
+#[function_component]
+fn Counter() -> Html {
+    let global_state = Dispatch::<State>::new().get();
+    let (state, dispatch) = use_store::<State>();
+    let onclick = dispatch.reduce_mut_callback(|state| state.count += 1);
+    html! {
+        <>
+        <p>{ global_state.count }</p>
+        <p>{ state.count }</p>
+        <button {onclick}>{"+1"}</button>
+        </>
+    }
+}
+
+#[function_component]
+fn App() -> Html {
+    html! {
+        <YewduxRoot>
+            <Counter />
+        </YewduxRoot>
+    }
+}
+
+fn main() {
+    yew::Renderer::<App>::new().render();
+}

--- a/examples/context_root/src/main.rs
+++ b/examples/context_root/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg(target_arch = "wasm32")]
+
 use yew::prelude::*;
 use yewdux::prelude::*;
 

--- a/examples/context_root/src/main.rs
+++ b/examples/context_root/src/main.rs
@@ -10,7 +10,7 @@ struct State {
 
 #[function_component]
 fn Counter() -> Html {
-    let global_state = Dispatch::<State>::new().get();
+    let global_state = Dispatch::<State>::global().get();
     let (state, dispatch) = use_store::<State>();
     let onclick = dispatch.reduce_mut_callback(|state| state.count += 1);
     html! {

--- a/examples/listener/src/main.rs
+++ b/examples/listener/src/main.rs
@@ -5,7 +5,8 @@ use yew::prelude::*;
 use yewdux::storage;
 use yewdux::{
     log::{log, Level},
-    prelude::*, Context,
+    prelude::*,
+    Context,
 };
 
 use serde::{Deserialize, Serialize};

--- a/examples/listener/src/main.rs
+++ b/examples/listener/src/main.rs
@@ -1,9 +1,9 @@
 use std::rc::Rc;
 
 use yew::prelude::*;
-use yewdux::prelude::*;
 #[cfg(target_arch = "wasm32")]
 use yewdux::storage;
+use yewdux::{context::Context, prelude::*};
 
 use serde::{Deserialize, Serialize};
 
@@ -32,7 +32,7 @@ impl Store for State {
 
     #[cfg(target_arch = "wasm32")]
     fn new() -> Self {
-        init_listener(StorageListener);
+        init_listener(StorageListener, &Context::global());
 
         storage::load(storage::Area::Local)
             .ok()

--- a/examples/listener/src/main.rs
+++ b/examples/listener/src/main.rs
@@ -1,9 +1,9 @@
 use std::rc::Rc;
 
 use yew::prelude::*;
+use yewdux::prelude::*;
 #[cfg(target_arch = "wasm32")]
 use yewdux::storage;
-use yewdux::{context::Context, prelude::*};
 
 use serde::{Deserialize, Serialize};
 
@@ -11,7 +11,7 @@ struct StorageListener;
 impl Listener for StorageListener {
     type Store = State;
 
-    fn on_change(&mut self, state: Rc<Self::Store>) {
+    fn on_change(&mut self, _cx: &yewdux::Context, state: Rc<Self::Store>) {
         #[cfg(target_arch = "wasm32")]
         if let Err(err) = storage::save(state.as_ref(), storage::Area::Local) {
             println!("Error saving state to storage: {:?}", err);
@@ -26,13 +26,13 @@ struct State {
 
 impl Store for State {
     #[cfg(not(target_arch = "wasm32"))]
-    fn new() -> Self {
+    fn new(_cx: &yewdux::Context) -> Self {
         Default::default()
     }
 
     #[cfg(target_arch = "wasm32")]
-    fn new() -> Self {
-        init_listener(StorageListener, &Context::global());
+    fn new(cx: &yewdux::Context) -> Self {
+        init_listener(StorageListener, cx);
 
         storage::load(storage::Area::Local)
             .ok()

--- a/examples/manual/src/main.rs
+++ b/examples/manual/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg(target_arch = "wasm32")]
+
 use std::rc::Rc;
 
 use yew::prelude::*;

--- a/examples/manual/src/main.rs
+++ b/examples/manual/src/main.rs
@@ -24,7 +24,7 @@ impl Component for App {
     type Properties = ();
 
     fn create(ctx: &Context<Self>) -> Self {
-        let dispatch = Dispatch::<State>::subscribe_global(ctx.link().callback(Msg::State));
+        let dispatch = Dispatch::<State>::new().subscribe(ctx.link().callback(Msg::State));
         Self {
             state: dispatch.get(),
             dispatch,

--- a/examples/manual/src/main.rs
+++ b/examples/manual/src/main.rs
@@ -26,7 +26,7 @@ impl Component for App {
     type Properties = ();
 
     fn create(ctx: &Context<Self>) -> Self {
-        let dispatch = Dispatch::<State>::new().subscribe(ctx.link().callback(Msg::State));
+        let dispatch = Dispatch::<State>::global().subscribe(ctx.link().callback(Msg::State));
         Self {
             state: dispatch.get(),
             dispatch,

--- a/examples/manual/src/main.rs
+++ b/examples/manual/src/main.rs
@@ -24,7 +24,7 @@ impl Component for App {
     type Properties = ();
 
     fn create(ctx: &Context<Self>) -> Self {
-        let dispatch = Dispatch::<State>::subscribe(ctx.link().callback(Msg::State));
+        let dispatch = Dispatch::<State>::subscribe_global(ctx.link().callback(Msg::State));
         Self {
             state: dispatch.get(),
             dispatch,

--- a/examples/selector/src/main.rs
+++ b/examples/selector/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg(target_arch = "wasm32")]
+
 use yew::prelude::*;
 use yewdux::prelude::*;
 

--- a/examples/selector/src/main.rs
+++ b/examples/selector/src/main.rs
@@ -9,7 +9,7 @@ struct State {
 #[function_component]
 fn App() -> Html {
     let count = use_selector(|state: &State| state.count);
-    let dispatch = Dispatch::<State>::new();
+    let dispatch = Dispatch::<State>::global();
     let onclick = dispatch.reduce_mut_callback(|state| state.count += 1);
 
     html! {

--- a/examples/selector/src/main.rs
+++ b/examples/selector/src/main.rs
@@ -9,7 +9,7 @@ struct State {
 #[function_component]
 fn App() -> Html {
     let count = use_selector(|state: &State| state.count);
-    let dispatch = Dispatch::<State>::global();
+    let dispatch = Dispatch::<State>::new();
     let onclick = dispatch.reduce_mut_callback(|state| state.count += 1);
 
     html! {

--- a/examples/selector/src/main.rs
+++ b/examples/selector/src/main.rs
@@ -11,7 +11,7 @@ struct State {
 #[function_component]
 fn App() -> Html {
     let count = use_selector(|state: &State| state.count);
-    let dispatch = Dispatch::<State>::new();
+    let dispatch = Dispatch::<State>::global();
     let onclick = dispatch.reduce_mut_callback(|state| state.count += 1);
 
     html! {

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -38,7 +38,7 @@ fn App() -> Html {
 
 #[function_component]
 fn Header() -> Html {
-    let onkeypress = Dispatch::<State>::new().reduce_mut_callback_with(|s, e: KeyboardEvent| {
+    let onkeypress = Dispatch::<State>::global().reduce_mut_callback_with(|s, e: KeyboardEvent| {
         if e.key() == "Enter" {
             let input: HtmlInputElement = e.target_unchecked_into();
             let value = input.value();
@@ -79,7 +79,7 @@ fn SelectFilter(&SelectFilterProps { active, target }: &SelectFilterProps) -> Ht
     } else {
         "not-selected"
     };
-    let onclick = Dispatch::<State>::new().reduce_mut_callback(move |s| s.filter = target);
+    let onclick = Dispatch::<State>::global().reduce_mut_callback(move |s| s.filter = target);
     html! {
         <li>
             <a class={cls} href={target.as_href()} {onclick}>
@@ -112,7 +112,7 @@ fn Footer() -> Html {
 #[function_component]
 fn BtnClearCompleted() -> Html {
     let total_completed = use_selector(|state: &State| state.total_completed());
-    let onclick = Dispatch::<State>::new().reduce_mut_callback(|s| s.clear_completed());
+    let onclick = Dispatch::<State>::global().reduce_mut_callback(|s| s.clear_completed());
 
     html! {
         <button class="clear-completed" {onclick} >
@@ -136,7 +136,7 @@ fn TodoCount() -> Html {
 #[function_component]
 fn ToggleAll() -> Html {
     let checked = use_selector(|state: &State| state.is_all_completed());
-    let onclick = Dispatch::new().reduce_mut_callback(|s: &mut State| {
+    let onclick = Dispatch::global().reduce_mut_callback(|s: &mut State| {
         let status = !s.is_all_completed();
         s.toggle_all(status);
     });

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -36,7 +36,7 @@ fn App() -> Html {
 
 #[function_component]
 fn Header() -> Html {
-    let onkeypress = Dispatch::<State>::global().reduce_mut_callback_with(|s, e: KeyboardEvent| {
+    let onkeypress = Dispatch::<State>::new().reduce_mut_callback_with(|s, e: KeyboardEvent| {
         if e.key() == "Enter" {
             let input: HtmlInputElement = e.target_unchecked_into();
             let value = input.value();
@@ -77,7 +77,7 @@ fn SelectFilter(&SelectFilterProps { active, target }: &SelectFilterProps) -> Ht
     } else {
         "not-selected"
     };
-    let onclick = Dispatch::<State>::global().reduce_mut_callback(move |s| s.filter = target);
+    let onclick = Dispatch::<State>::new().reduce_mut_callback(move |s| s.filter = target);
     html! {
         <li>
             <a class={cls} href={target.as_href()} {onclick}>
@@ -110,7 +110,7 @@ fn Footer() -> Html {
 #[function_component]
 fn BtnClearCompleted() -> Html {
     let total_completed = use_selector(|state: &State| state.total_completed());
-    let onclick = Dispatch::<State>::global().reduce_mut_callback(|s| s.clear_completed());
+    let onclick = Dispatch::<State>::new().reduce_mut_callback(|s| s.clear_completed());
 
     html! {
         <button class="clear-completed" {onclick} >
@@ -134,7 +134,7 @@ fn TodoCount() -> Html {
 #[function_component]
 fn ToggleAll() -> Html {
     let checked = use_selector(|state: &State| state.is_all_completed());
-    let onclick = Dispatch::global().reduce_mut_callback(|s: &mut State| {
+    let onclick = Dispatch::new().reduce_mut_callback(|s: &mut State| {
         let status = !s.is_all_completed();
         s.toggle_all(status);
     });

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -36,7 +36,7 @@ fn App() -> Html {
 
 #[function_component]
 fn Header() -> Html {
-    let onkeypress = Dispatch::<State>::new().reduce_mut_callback_with(|s, e: KeyboardEvent| {
+    let onkeypress = Dispatch::<State>::global().reduce_mut_callback_with(|s, e: KeyboardEvent| {
         if e.key() == "Enter" {
             let input: HtmlInputElement = e.target_unchecked_into();
             let value = input.value();
@@ -77,7 +77,7 @@ fn SelectFilter(&SelectFilterProps { active, target }: &SelectFilterProps) -> Ht
     } else {
         "not-selected"
     };
-    let onclick = Dispatch::<State>::new().reduce_mut_callback(move |s| s.filter = target);
+    let onclick = Dispatch::<State>::global().reduce_mut_callback(move |s| s.filter = target);
     html! {
         <li>
             <a class={cls} href={target.as_href()} {onclick}>
@@ -110,7 +110,7 @@ fn Footer() -> Html {
 #[function_component]
 fn BtnClearCompleted() -> Html {
     let total_completed = use_selector(|state: &State| state.total_completed());
-    let onclick = Dispatch::<State>::new().reduce_mut_callback(|s| s.clear_completed());
+    let onclick = Dispatch::<State>::global().reduce_mut_callback(|s| s.clear_completed());
 
     html! {
         <button class="clear-completed" {onclick} >
@@ -134,7 +134,7 @@ fn TodoCount() -> Html {
 #[function_component]
 fn ToggleAll() -> Html {
     let checked = use_selector(|state: &State| state.is_all_completed());
-    let onclick = Dispatch::new().reduce_mut_callback(|s: &mut State| {
+    let onclick = Dispatch::global().reduce_mut_callback(|s: &mut State| {
         let status = !s.is_all_completed();
         s.toggle_all(status);
     });

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg(target_arch = "wasm32")]
+
 mod state;
 
 use web_sys::HtmlInputElement;


### PR DESCRIPTION
Primarily important for SSR support, containing state to the scope of the app, instead of the thread.

For a basic example, you can now create a local context for your dispatch:

```rust
#[derive(Clone, PartialEq, Default, Store)]
struct Counter(u32);

let cx = yewdux::Context::new();
let dispatch = Dispatch::<Counter>::new(&cx);
```

Changes to one context are not reflected in any others:
```rust
let cx_1 = yewdux::Context::new();
let dispatch_1 = Dispatch::<Counter>::new(&cx_1);

let cx_2 = yewdux::Context::new();
let dispatch_2 = Dispatch::<Counter>::new(&cx_2);

dispatch_1.set(Counter(1));
dispatch_2.set(Counter(2));

assert_ne!(dispatch_1.get(), dispatch_2.get());
```

The default context for a dispatch is global (thread local).
```rust
let dispatch_1 = Dispatch::<Counter>::global();
// This is equivalent to above.
let dispatch_2 = Dispatch::<Counter>::new(&yewdux::Context::global());

dispatch_1.set(Counter(1));

assert_eq!(dispatch_1.get(), dispatch_2.get());
``` 

A root component is now available to provide context that is scoped to the app:
```rust
use yew::prelude::*;
use yewdux::prelude::*;

#[derive(Default, Clone, PartialEq, Eq, Store)]
struct State {
    count: u32,
}

#[function_component]
fn Counter() -> Html {
    let (state, dispatch) = use_store::<State>();
    let onclick = dispatch.reduce_mut_callback(|state| state.count += 1);
    html! {
        <>
        <p>{ state.count }</p>
        <button {onclick}>{"+1"}</button>
        </>
    }
}

#[function_component]
fn App() -> Html {
    html! {
        <YewduxRoot>
            <Counter />
        </YewduxRoot>
    }
}
```

Hooks will detect the context provided by `YewduxRoot`. If no root is provided, it uses global by default.