### PR TITLE
Listener Injection

### DIFF
--- a/crates/yewdux-input/src/lib.rs
+++ b/crates/yewdux-input/src/lib.rs
@@ -1,10 +1,10 @@
 use std::{rc::Rc, str::FromStr};
 
+use serde::{Deserialize, Serialize};
 use wasm_bindgen::JsCast;
 use web_sys::{HtmlInputElement, HtmlTextAreaElement};
 use yew::prelude::*;
 use yewdux::prelude::*;
-use serde::{Deserialize, Serialize};
 
 pub enum InputElement {
     Input(HtmlInputElement),

--- a/crates/yewdux-macros/src/store.rs
+++ b/crates/yewdux-macros/src/store.rs
@@ -1,4 +1,4 @@
-use darling::{FromDeriveInput, util::PathList};
+use darling::{util::PathList, FromDeriveInput};
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::DeriveInput;
@@ -8,7 +8,7 @@ use syn::DeriveInput;
 struct Opts {
     storage: Option<String>,
     storage_tab_sync: bool,
-    listener: PathList
+    listener: PathList,
 }
 
 pub(crate) fn derive(input: DeriveInput) -> TokenStream {
@@ -16,14 +16,17 @@ pub(crate) fn derive(input: DeriveInput) -> TokenStream {
     let ident = input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
-
-    let extra_listeners : Vec<_> = opts.listener.iter().map(|path|
-        quote!{
-            ::yewdux::listener::init_listener(
-                #path
-            );
-        }
-    ).collect();
+    let extra_listeners: Vec<_> = opts
+        .listener
+        .iter()
+        .map(|path| {
+            quote! {
+                ::yewdux::listener::init_listener(
+                    #path
+                );
+            }
+        })
+        .collect();
 
     let impl_ = match opts.storage {
         Some(storage) => {
@@ -45,8 +48,6 @@ pub(crate) fn derive(input: DeriveInput) -> TokenStream {
             } else {
                 quote!()
             };
-
-
 
             quote! {
                 #[cfg(target_arch = "wasm32")]

--- a/crates/yewdux/src/listener.rs
+++ b/crates/yewdux/src/listener.rs
@@ -9,16 +9,16 @@ pub trait Listener: 'static {
     fn on_change(&mut self, state: Rc<Self::Store>);
 }
 
-struct ListenerStore<L : Listener>(Option<SubscriberId<L::Store>>);
-    impl<L : Listener> Store for Mrc<ListenerStore<L>> {
-        fn new() -> Self {
-            ListenerStore(None).into()
-        }
-
-        fn should_notify(&self, other: &Self) -> bool {
-            self != other
-        }
+struct ListenerStore<L: Listener>(Option<SubscriberId<L::Store>>);
+impl<L: Listener> Store for Mrc<ListenerStore<L>> {
+    fn new() -> Self {
+        ListenerStore(None).into()
     }
+
+    fn should_notify(&self, other: &Self) -> bool {
+        self != other
+    }
+}
 
 /// Initiate a [Listener]. If this listener has already been initiated, it is dropped and replaced
 /// with the new one.
@@ -28,9 +28,7 @@ pub fn init_listener<L: Listener>(listener: L) {
         dispatch::subscribe_silent(move |state| listener.borrow_mut().on_change(state))
     };
 
-    dispatch::reduce_mut(|state: &mut Mrc<ListenerStore<L>>| {
-        state.borrow_mut().0 = Some(id)
-    });
+    dispatch::reduce_mut(|state: &mut Mrc<ListenerStore<L>>| state.borrow_mut().0 = Some(id));
 }
 
 #[cfg(test)]

--- a/crates/yewdux/src/listener.rs
+++ b/crates/yewdux/src/listener.rs
@@ -9,16 +9,16 @@ pub trait Listener: 'static {
     fn on_change(&mut self, state: Rc<Self::Store>);
 }
 
-struct ListenerStore<S: Store>(Option<SubscriberId<S>>);
-impl<S: Store> Store for Mrc<ListenerStore<S>> {
-    fn new() -> Self {
-        ListenerStore(None).into()
-    }
+struct ListenerStore<L : Listener>(Option<SubscriberId<L::Store>>);
+    impl<L : Listener> Store for Mrc<ListenerStore<L>> {
+        fn new() -> Self {
+            ListenerStore(None).into()
+        }
 
-    fn should_notify(&self, other: &Self) -> bool {
-        self != other
+        fn should_notify(&self, other: &Self) -> bool {
+            self != other
+        }
     }
-}
 
 /// Initiate a [Listener]. If this listener has already been initiated, it is dropped and replaced
 /// with the new one.
@@ -28,7 +28,7 @@ pub fn init_listener<L: Listener>(listener: L) {
         dispatch::subscribe_silent(move |state| listener.borrow_mut().on_change(state))
     };
 
-    dispatch::reduce_mut(|state: &mut Mrc<ListenerStore<L::Store>>| {
+    dispatch::reduce_mut(|state: &mut Mrc<ListenerStore<L>>| {
         state.borrow_mut().0 = Some(id)
     });
 }
@@ -55,6 +55,16 @@ mod tests {
     #[derive(Clone)]
     struct TestListener(Rc<Cell<u32>>);
     impl Listener for TestListener {
+        type Store = TestState;
+
+        fn on_change(&mut self, state: Rc<Self::Store>) {
+            self.0.set(state.0);
+        }
+    }
+
+    #[derive(Clone)]
+    struct AnotherTestListener(Rc<Cell<u32>>);
+    impl Listener for AnotherTestListener {
         type Store = TestState;
 
         fn on_change(&mut self, state: Rc<Self::Store>) {
@@ -110,6 +120,25 @@ mod tests {
         dispatch::reduce_mut(|state: &mut TestState| state.0 = 2);
 
         assert_eq!(listener1.0.get(), 1);
+        assert_eq!(listener2.0.get(), 2);
+    }
+
+    #[test]
+    fn listener_of_different_type_is_not_replaced() {
+        let listener1 = TestListener(Default::default());
+        let listener2 = AnotherTestListener(Default::default());
+
+        init_listener(listener1.clone());
+
+        dispatch::reduce_mut(|state: &mut TestState| state.0 = 1);
+
+        assert_eq!(listener1.0.get(), 1);
+
+        init_listener(listener2.clone());
+
+        dispatch::reduce_mut(|state: &mut TestState| state.0 = 2);
+
+        assert_eq!(listener1.0.get(), 2);
         assert_eq!(listener2.0.get(), 2);
     }
 

--- a/docs/src/persistence.md
+++ b/docs/src/persistence.md
@@ -46,3 +46,24 @@ struct State {
 }
 ```
 
+## Additional Listeners
+
+You can inject additional listeners into the `#[store]` macro.
+
+```rust
+#[derive(Default, Clone, PartialEq, Eq, Deserialize, Serialize, Store)]
+#[store(storage = "local", listener(LogListener))]
+struct State {
+    count: u32,
+}
+
+struct LogListener;
+impl Listener for LogListener {
+    type Store = State;
+
+    fn on_change(&mut self, state: Rc<Self::Store>) {
+        log!(Level::Info, "Count changed to {}", state.count);
+    }
+}
+```
+

--- a/examples/listener/Cargo.toml
+++ b/examples/listener/Cargo.toml
@@ -7,5 +7,6 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1.0.114" }
+wasm-logger = "0.2.0"
 yew = { git = "https://github.com/yewstack/yew.git", features = ["csr"] }
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/listener/src/main.rs
+++ b/examples/listener/src/main.rs
@@ -1,11 +1,23 @@
 use std::rc::Rc;
 
 use yew::prelude::*;
-use yewdux::prelude::*;
 #[cfg(target_arch = "wasm32")]
 use yewdux::storage;
+use yewdux::{
+    log::{log, Level},
+    prelude::*,
+};
 
 use serde::{Deserialize, Serialize};
+
+struct LogListener;
+impl Listener for LogListener {
+    type Store = State;
+
+    fn on_change(&mut self, _state: Rc<Self::Store>) {
+        log!(Level::Info, "State has changed");
+    }
+}
 
 struct StorageListener;
 impl Listener for StorageListener {
@@ -33,6 +45,7 @@ impl Store for State {
     #[cfg(target_arch = "wasm32")]
     fn new() -> Self {
         init_listener(StorageListener);
+        init_listener(LogListener);
 
         storage::load(storage::Area::Local)
             .ok()
@@ -59,5 +72,6 @@ fn App() -> Html {
 }
 
 fn main() {
+    wasm_logger::init(wasm_logger::Config::default());
     yew::Renderer::<App>::new().render();
 }

--- a/examples/listener/src/main.rs
+++ b/examples/listener/src/main.rs
@@ -14,8 +14,8 @@ struct LogListener;
 impl Listener for LogListener {
     type Store = State;
 
-    fn on_change(&mut self, _state: Rc<Self::Store>) {
-        log!(Level::Info, "State has changed");
+    fn on_change(&mut self, state: Rc<Self::Store>) {
+        log!(Level::Info, "Count changed to {}", state.count);
     }
 }
 

--- a/examples/persistent/Cargo.toml
+++ b/examples/persistent/Cargo.toml
@@ -7,5 +7,6 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1.0.114" }
+wasm-logger = "0.2.0"
 yew = { git = "https://github.com/yewstack/yew.git", features = ["csr"] }
 yewdux = { path = "../../crates/yewdux" }

--- a/examples/persistent/src/main.rs
+++ b/examples/persistent/src/main.rs
@@ -1,7 +1,10 @@
 use std::rc::Rc;
 
 use yew::prelude::*;
-use yewdux::{prelude::*, log::{log, Level}};
+use yewdux::{
+    log::{log, Level},
+    prelude::*,
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -28,7 +31,6 @@ fn main() {
     wasm_logger::init(wasm_logger::Config::default());
     yew::Renderer::<App>::new().render();
 }
-
 
 struct LogListener;
 impl Listener for LogListener {

--- a/examples/persistent/src/main.rs
+++ b/examples/persistent/src/main.rs
@@ -1,5 +1,7 @@
+use std::rc::Rc;
+
 use yew::prelude::*;
-use yewdux::prelude::*;
+use yewdux::{prelude::*, log::{log, Level}};
 
 use serde::{Deserialize, Serialize};
 
@@ -23,5 +25,16 @@ fn App() -> Html {
 }
 
 fn main() {
+    wasm_logger::init(wasm_logger::Config::default());
     yew::Renderer::<App>::new().render();
+}
+
+
+struct LogListener;
+impl Listener for LogListener {
+    type Store = State;
+
+    fn on_change(&mut self, _state: Rc<Self::Store>) {
+        log!(Level::Info, "State has changed 123");
+    }
 }

--- a/examples/persistent/src/main.rs
+++ b/examples/persistent/src/main.rs
@@ -6,7 +6,7 @@ use yewdux::{prelude::*, log::{log, Level}};
 use serde::{Deserialize, Serialize};
 
 #[derive(Default, Clone, PartialEq, Eq, Deserialize, Serialize, Store)]
-#[store(storage = "local")]
+#[store(storage = "local", listener(LogListener))]
 struct State {
     count: u32,
 }
@@ -34,7 +34,7 @@ struct LogListener;
 impl Listener for LogListener {
     type Store = State;
 
-    fn on_change(&mut self, _state: Rc<Self::Store>) {
-        log!(Level::Info, "State has changed 123");
+    fn on_change(&mut self, state: Rc<Self::Store>) {
+        log!(Level::Info, "Count changed to {}", state.count);
     }
 }

--- a/examples/todomvc/src/state.rs
+++ b/examples/todomvc/src/state.rs
@@ -119,8 +119,7 @@ pub struct Entry {
     pub editing: bool,
 }
 
-#[derive(Clone, Copy, Debug, EnumIter, Display, PartialEq, Eq, Serialize, Deserialize)]
-#[derive(Default)]
+#[derive(Clone, Copy, Debug, EnumIter, Display, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum Filter {
     #[default]
     All,
@@ -145,5 +144,3 @@ impl Filter {
         }
     }
 }
-
-


### PR DESCRIPTION
Closes https://github.com/intendednull/yewdux/issues/51

This allows you to inject listeners into the `#[store]` macro

```rust 
#[derive(Default, Clone, PartialEq, Eq, Deserialize, Serialize, Store)]
#[store(storage = "local", listener(LogListener))]
struct State {
    count: u32,
}

struct LogListener;
impl Listener for LogListener {
    type Store = State;

    fn on_change(&mut self, state: Rc<Self::Store>) {
        log!(Level::Info, "Count changed to {}", state.count);
    }
}
```


This also fixes a bug where adding more than one listener would drop previous listeners.