### PR TITLE
doc: Clarify how store can be accessed outside of components

### DIFF
--- a/docs/src/dispatch.md
+++ b/docs/src/dispatch.md
@@ -6,13 +6,13 @@ read and write changes to state in various ways.
 
 # Creating a Dispatch
 
-To create a dispatch, you need only provide the desired store type.
+To create a dispatch, you need only provide the desired store type. This is available in **any** rust code, not just yew components.
 
 ```rust
 let dispatch = Dispatch::<Counter>::new();
 ```
 
-A dispatch is also given when using the functional hook.
+A dispatch is also given when using the functional hook, which is only available in yew components.
 
 ```rust
 let (state, dispatch) = use_store::<Counter>();


### PR DESCRIPTION
Here is a small addition to the documentation that emphasizes how the state can be accessed outside of a yew component. A single line that would have saved me a lot of time starting out with yewdux. 

This works on #65.