### PR TITLE
Preserve reduce_mut return value

### DIFF
--- a/crates/yewdux/src/dispatch.rs
+++ b/crates/yewdux/src/dispatch.rs
@@ -551,14 +551,18 @@ impl<S: Store> Dispatch<S> {
     /// dispatch.reduce_mut(|state| state.count += 1);
     /// # }
     /// ```
-    pub fn reduce_mut<F, R>(&self, f: F)
+    pub fn reduce_mut<F, R>(&self, f: F) -> R
     where
         S: Clone,
         F: FnOnce(&mut S) -> R,
     {
+        let mut result = None;
+        
         reduce_mut(|x| {
-            f(x);
+            result = Some(f(x));
         });
+
+        result.expect("result not initialized")
     }
 
     /// Mutate state with given function, in an async context.

--- a/examples/history/src/main.rs
+++ b/examples/history/src/main.rs
@@ -55,7 +55,7 @@ fn Controls() -> Html {
         .enumerate()
         .map(|(i, x)| {
             let matches = i == state.index();
-            let match_text = matches.then_some("<<<");
+            let match_text = matches.then_some("<<<").unwrap_or("");
             let text = format!("{x:?}");
 
             let onclick = dispatch.apply_callback(move |_| HistoryMessage::JumpTo(i));


### PR DESCRIPTION
Previously the returned value of reduce_mut was dropped. Now that value is returned to the caller:

```rust
let previous_count = dispatch.reduce_mut(|state| {
    let previous_count = state.count;
    
    state.count += 1;

    previous_count
});
```